### PR TITLE
add fallback to bintray properties

### DIFF
--- a/simpleast-core/build.gradle
+++ b/simpleast-core/build.gradle
@@ -104,8 +104,8 @@ publishing {
 }
 
 bintray {
-    user = bintrayUser
-    key = bintrayApiKey
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+    key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
 
     publications = ['Release']
     pkg {
@@ -120,7 +120,9 @@ bintray {
         version {
             gpg {
                 sign = true
-                passphrase = discord_bintray_gpg_passphrase
+                passphrase = project.hasProperty('discord_bintray_gpg_passphrase') ?
+                        project.property('discord_bintray_gpg_passphrase') :
+                        System.getenv('DISCORD_BINTRAY_GPG_PASSPHRASE')
             }
         }
     }


### PR DESCRIPTION
Background:
I just checked out this project and was trying to playing around with it, but the android studio/gradle sync gives me error saying a couple of bintray properties can't be resolved, and thus I can't start the sample app.

I think it might be more developer friendly to have a fallback to project property (otherwise all new devs has to figure out the error messages and manually add some fake gradle project properties after checking out the project even though they don't have permission and don't intent to publish a release at all).

Change:
Add some system env fallback to the bintray project properties. Following the convention in https://github.com/bintray/bintray-examples/blob/master/gradle-bintray-plugin-examples/configurations-example/build.gradle#L38

A better option might be lazy evaluate bintray property on publish command, but I googled a bit and seems it is not properly supported yet.

Test:
1) verified adding bintrayUser project property still reads from bintrayUser project property.
2) remove all bintray related properties, clean the project, and watch the project build fine.

Please let me know what you think. :)