### PR TITLE
Filter nested skipping rule at earlier time

### DIFF
--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
@@ -43,10 +43,6 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
 
       var foundRule = false
       for (rule in filteredRules) {
-        if (isNested && !rule.applyOnNestedParse) {
-          continue
-        }
-
         val matcher = rule.matcher.reset(inspectionSource)
 
         if (matcher.find()) {

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
@@ -2,7 +2,7 @@ package com.discord.simpleast.core.parser
 
 import android.util.Log
 import com.discord.simpleast.core.node.Node
-import java.util.*
+import java.util.Stack
 
 open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDebugging: Boolean = false) {
 
@@ -29,6 +29,8 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
       remainingParses.add(ParseSpec(null, 0, source.length))
     }
 
+    val filteredRules = if (isNested) rules.filter { it.applyOnNestedParse } else rules
+
     while (!remainingParses.isEmpty()) {
       val builder = remainingParses.pop()
 
@@ -40,7 +42,7 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
       val offset = builder.startIndex
 
       var foundRule = false
-      for (rule in rules) {
+      for (rule in filteredRules) {
         if (isNested && !rule.applyOnNestedParse) {
           continue
         }
@@ -103,6 +105,6 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
 
   companion object {
 
-    private val TAG = "Parser"
+    private const val TAG = "Parser"
   }
 }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
@@ -11,19 +11,18 @@ import com.discord.simpleast.core.node.TextNode
 import com.discord.simpleast.core.parser.ParseSpec
 import com.discord.simpleast.core.parser.Parser
 import com.discord.simpleast.core.parser.Rule
-import java.util.*
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 object SimpleMarkdownRules {
 
-  val PATTERN_BOLD = Pattern.compile("^\\*\\*([\\s\\S]+?)\\*\\*(?!\\*)")
-  val PATTERN_UNDERLINE = Pattern.compile("^__([\\s\\S]+?)__(?!_)")
-  val PATTERN_STRIKETHRU = Pattern.compile("^~~(?=\\S)([\\s\\S]*?\\S)~~")
-  val PATTERN_TEXT = Pattern.compile("^[\\s\\S]+?(?=[^0-9A-Za-z\\s\\u00c0-\\uffff]|\\n\\n| {2,}\\n|\\w+:\\S|$)")
-  val PATTERN_ESCAPE = Pattern.compile("^\\\\([^0-9A-Za-z\\s])")
+  private val PATTERN_BOLD = Pattern.compile("^\\*\\*([\\s\\S]+?)\\*\\*(?!\\*)")
+  private val PATTERN_UNDERLINE = Pattern.compile("^__([\\s\\S]+?)__(?!_)")
+  private val PATTERN_STRIKETHRU = Pattern.compile("^~~(?=\\S)([\\s\\S]*?\\S)~~")
+  private val PATTERN_TEXT = Pattern.compile("^[\\s\\S]+?(?=[^0-9A-Za-z\\s\\u00c0-\\uffff]|\\n\\n| {2,}\\n|\\w+:\\S|$)")
+  private val PATTERN_ESCAPE = Pattern.compile("^\\\\([^0-9A-Za-z\\s])")
 
-  val PATTERN_ITALICS = Pattern.compile(
+  private val PATTERN_ITALICS = Pattern.compile(
       // only match _s surrounding words.
       "^\\b_" + "((?:__|\\\\[\\s\\S]|[^\\\\_])+?)_" + "\\b" +
           "|" +
@@ -39,16 +38,16 @@ object SimpleMarkdownRules {
           ")\\*(?!\\*)"
   )
 
-  fun <R> createBoldRule(): Rule<R, Node<R>> =
+  private fun <R> createBoldRule(): Rule<R, Node<R>> =
       createSimpleStyleRule(PATTERN_BOLD, { listOf(StyleSpan(Typeface.BOLD)) })
 
-  fun <R> createUnderlineRule(): Rule<R, Node<R>> =
+  private fun <R> createUnderlineRule(): Rule<R, Node<R>> =
       createSimpleStyleRule(PATTERN_UNDERLINE, { listOf(UnderlineSpan()) })
 
-  fun <R> createStrikethruRule(): Rule<R, Node<R>> =
+  private fun <R> createStrikethruRule(): Rule<R, Node<R>> =
       createSimpleStyleRule(PATTERN_STRIKETHRU, { listOf(StrikethroughSpan()) })
 
-  fun <R> createTextRule(): Rule<R, Node<R>> {
+  private fun <R> createTextRule(): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(PATTERN_TEXT, true) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
         val node = TextNode<R>(matcher.group())
@@ -57,7 +56,7 @@ object SimpleMarkdownRules {
     }
   }
 
-  fun <R> createEscapeRule(): Rule<R, Node<R>> {
+  private fun <R> createEscapeRule(): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(PATTERN_ESCAPE, false) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
         return ParseSpec.createTerminal(TextNode(matcher.group(1)))
@@ -65,7 +64,7 @@ object SimpleMarkdownRules {
     }
   }
 
-  fun <R> createItalicsRule(): Rule<R, Node<R>> {
+  private fun <R> createItalicsRule(): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(PATTERN_ITALICS, false) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
         val startIndex: Int
@@ -103,7 +102,7 @@ object SimpleMarkdownRules {
   }
 
   @JvmStatic
-  fun <R> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>): Rule<R, Node<R>> {
+  private fun <R> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(pattern, false) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
         val node = StyleNode<R>(styleFactory())

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
@@ -16,13 +16,13 @@ import java.util.regex.Pattern
 
 object SimpleMarkdownRules {
 
-  private val PATTERN_BOLD = Pattern.compile("^\\*\\*([\\s\\S]+?)\\*\\*(?!\\*)")
-  private val PATTERN_UNDERLINE = Pattern.compile("^__([\\s\\S]+?)__(?!_)")
-  private val PATTERN_STRIKETHRU = Pattern.compile("^~~(?=\\S)([\\s\\S]*?\\S)~~")
-  private val PATTERN_TEXT = Pattern.compile("^[\\s\\S]+?(?=[^0-9A-Za-z\\s\\u00c0-\\uffff]|\\n\\n| {2,}\\n|\\w+:\\S|$)")
-  private val PATTERN_ESCAPE = Pattern.compile("^\\\\([^0-9A-Za-z\\s])")
+  val PATTERN_BOLD = Pattern.compile("^\\*\\*([\\s\\S]+?)\\*\\*(?!\\*)")
+  val PATTERN_UNDERLINE = Pattern.compile("^__([\\s\\S]+?)__(?!_)")
+  val PATTERN_STRIKETHRU = Pattern.compile("^~~(?=\\S)([\\s\\S]*?\\S)~~")
+  val PATTERN_TEXT = Pattern.compile("^[\\s\\S]+?(?=[^0-9A-Za-z\\s\\u00c0-\\uffff]|\\n\\n| {2,}\\n|\\w+:\\S|$)")
+  val PATTERN_ESCAPE = Pattern.compile("^\\\\([^0-9A-Za-z\\s])")
 
-  private val PATTERN_ITALICS = Pattern.compile(
+  val PATTERN_ITALICS = Pattern.compile(
       // only match _s surrounding words.
       "^\\b_" + "((?:__|\\\\[\\s\\S]|[^\\\\_])+?)_" + "\\b" +
           "|" +
@@ -38,16 +38,16 @@ object SimpleMarkdownRules {
           ")\\*(?!\\*)"
   )
 
-  private fun <R> createBoldRule(): Rule<R, Node<R>> =
+  fun <R> createBoldRule(): Rule<R, Node<R>> =
       createSimpleStyleRule(PATTERN_BOLD, { listOf(StyleSpan(Typeface.BOLD)) })
 
-  private fun <R> createUnderlineRule(): Rule<R, Node<R>> =
+  fun <R> createUnderlineRule(): Rule<R, Node<R>> =
       createSimpleStyleRule(PATTERN_UNDERLINE, { listOf(UnderlineSpan()) })
 
-  private fun <R> createStrikethruRule(): Rule<R, Node<R>> =
+  fun <R> createStrikethruRule(): Rule<R, Node<R>> =
       createSimpleStyleRule(PATTERN_STRIKETHRU, { listOf(StrikethroughSpan()) })
 
-  private fun <R> createTextRule(): Rule<R, Node<R>> {
+  fun <R> createTextRule(): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(PATTERN_TEXT, true) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
         val node = TextNode<R>(matcher.group())
@@ -56,7 +56,7 @@ object SimpleMarkdownRules {
     }
   }
 
-  private fun <R> createEscapeRule(): Rule<R, Node<R>> {
+  fun <R> createEscapeRule(): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(PATTERN_ESCAPE, false) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
         return ParseSpec.createTerminal(TextNode(matcher.group(1)))
@@ -64,7 +64,7 @@ object SimpleMarkdownRules {
     }
   }
 
-  private fun <R> createItalicsRule(): Rule<R, Node<R>> {
+  fun <R> createItalicsRule(): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(PATTERN_ITALICS, false) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
         val startIndex: Int
@@ -102,7 +102,7 @@ object SimpleMarkdownRules {
   }
 
   @JvmStatic
-  private fun <R> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>): Rule<R, Node<R>> {
+  fun <R> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(pattern, false) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
         val node = StyleNode<R>(styleFactory())

--- a/simpleast-core/src/test/java/com/discord/simpleast/core/ParserTest.java
+++ b/simpleast-core/src/test/java/com/discord/simpleast/core/ParserTest.java
@@ -40,13 +40,13 @@ public class ParserTest {
     }
 
     @Test
-    public void testEmptyParse() throws Exception {
+    public void testEmptyParse() {
         final List<Node<Object>> ast = parser.parse("");
         Assert.assertTrue(ast.isEmpty());
     }
 
     @Test
-    public void testParseFormattedText() throws Exception {
+    public void testParseFormattedText() {
         final List<Node<Object>> ast = parser.parse("**bold**");
 
         final StyleNode boldNode = StyleNode.Companion.createWithText("bold", Collections.singletonList((CharacterStyle) new StyleSpan(Typeface.BOLD)));
@@ -56,7 +56,7 @@ public class ParserTest {
     }
 
     @Test
-    public void testParseLeadingFormatting() throws Exception {
+    public void testParseLeadingFormatting() {
         final List<Node<Object>> ast = parser.parse("**bold** and not bold");
 
         final StyleNode boldNode = StyleNode.Companion.createWithText("bold", Collections.singletonList((CharacterStyle) new StyleSpan(Typeface.BOLD)));
@@ -67,7 +67,7 @@ public class ParserTest {
     }
 
     @Test
-    public void testParseTrailingFormatting() throws Exception {
+    public void testParseTrailingFormatting() {
         final List<Node<Object>> ast = parser.parse("not bold **and bold**");
 
         final TextNode leadingText = new TextNode("not bold ");
@@ -78,7 +78,7 @@ public class ParserTest {
     }
 
     @Test
-    public void testNestedFormatting() throws Exception {
+    public void testNestedFormatting() {
 //        final List<Node> ast = parser.parse("*** test1 ** test2 * test3 * test4 ** test5 ***");
         final List<Node<Object>> ast = parser.parse("**bold *and italics* and more bold**");
 //        final List<Node> ast = parser.parse("______" +


### PR DESCRIPTION
For now we are checking the nested rule setting on every pass, which can result in empty cycles. Since all these can be determined beforehand, we can just get a pre filtered rule list.

It is not a bottleneck of the performance at all. But it is a low hanging fruit to push performance faster in the case there are larger number of passes. With my change I ran the profiling with test string `**test*case*zero**one**two**three**four**` and see the average time from parsing went down from 547.56s to 542.02s. (a very small ~1.01% improvements).

Also clean up some codes I saw along the way. Please let me know if any of these make sense. Thanks!