### PR TITLE
Feature: Support code language highlighting

### DIFF
--- a/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
@@ -119,4 +119,11 @@ object CustomMarkdownRules {
       }
     }
   }
+
+  fun <RC, S : BlockQuoteState<S>> createCodeInlineRule(context: Context): Rule<RC, Node<RC>, S> {
+    return CodeRules.createInlineCodeRule(
+        { listOf(TextAppearanceSpan(context, R.style.Code_TextAppearance)) },
+        { listOf(BackgroundColorSpan(Color.DKGRAY)) },
+    )
+  }
 }

--- a/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
@@ -6,12 +6,15 @@ import android.graphics.Typeface
 import android.text.style.*
 import androidx.annotation.StyleRes
 import com.discord.simpleast.R
+import com.discord.simpleast.code.CodeRules
+import com.discord.simpleast.code.CodeStyleProviders
 import com.discord.simpleast.core.node.Node
 import com.discord.simpleast.core.node.StyleNode
 import com.discord.simpleast.core.parser.ParseSpec
 import com.discord.simpleast.core.parser.Parser
 import com.discord.simpleast.core.parser.Rule
 import com.discord.simpleast.markdown.MarkdownRules
+import com.discord.simpleast.sample.spans.BlockBackgroundNode
 import com.discord.simpleast.sample.spans.VerticalMarginSpan
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -72,7 +75,8 @@ object CustomMarkdownRules {
      */
     private val PATTERN_BLOCK_QUOTE = Pattern.compile("^(?: *>>> ?(.+)| *>(?!>>) ?([^\\n]+\\n?))", Pattern.DOTALL)
 
-    class BlockQuoteNode<RC> : StyleNode<RC, BackgroundColorSpan>(listOf(BackgroundColorSpan(Color.GRAY)))
+    class BlockQuoteNode<RC> : StyleNode<RC, Any>(listOf(
+        LeadingMarginSpan.Standard(40), BackgroundColorSpan(Color.GRAY)))
 
     // Use a block rule to ensure we only match at the beginning of a line.
     fun <RC, S: BlockQuoteState<S>> createBlockQuoteRule(): Rule.BlockRule<RC, BlockQuoteNode<RC>, S> =
@@ -88,4 +92,31 @@ object CustomMarkdownRules {
                     return ParseSpec.createNonterminal(BlockQuoteNode(), newState, matcher.start(groupIndex), matcher.end(groupIndex))
                 }
             }
+
+
+  fun <RC, S: BlockQuoteState<S>> createCodeRule(context: Context): Rule<RC, Node<RC>, S> {
+    val codeStyleProviders = CodeStyleProviders<RC>(
+        defaultStyleProvider = { listOf(TextAppearanceSpan(context, R.style.Code_TextAppearance)) },
+        commentStyleProvider = { listOf(TextAppearanceSpan(context, R.style.Code_TextAppearance_Comment)) },
+        literalStyleProvider = { listOf(TextAppearanceSpan(context, R.style.Code_TextAppearance_Literal)) },
+        keywordStyleProvider = { listOf(TextAppearanceSpan(context, R.style.Code_TextAppearance_Keyword)) },
+        identifierStyleProvider = { listOf(TextAppearanceSpan(context, R.style.Code_TextAppearance_Identifier)) },
+        typesStyleProvider = { listOf(TextAppearanceSpan(context, R.style.Code_TextAppearance_Types)) },
+        genericsStyleProvider = { listOf(TextAppearanceSpan(context, R.style.Code_TextAppearance_Generics)) },
+        paramsStyleProvider = { listOf(TextAppearanceSpan(context, R.style.Code_TextAppearance_Params)) },
+    )
+    val languageMap = CodeRules.createCodeLanguageMap<RC, S>(codeStyleProviders)
+
+    return CodeRules.createCodeRule(
+        codeStyleProviders.defaultStyleProvider,
+        languageMap
+    ) { codeNode, block, state ->
+      if (!block) {
+        StyleNode<RC, Any>(listOf(BackgroundColorSpan(Color.DKGRAY)))
+            .apply { addChild(codeNode) }
+      } else {
+        BlockBackgroundNode(state.isInQuote, codeNode)
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -76,7 +76,9 @@ class MainActivity : AppCompatActivity() {
               this@MainActivity,
               listOf(R.style.Demo_Header_1, R.style.Demo_Header_2, R.style.Demo_Header_3),
               listOf(R.style.Demo_Header_1_Add, R.style.Demo_Header_1_Remove, R.style.Demo_Header_1_Fix)))
-          .addRule(CustomMarkdownRules.createCodeRule(this@MainActivity))
+          .addRules(
+              CustomMarkdownRules.createCodeRule(this@MainActivity),
+              CustomMarkdownRules.createCodeInlineRule(this@MainActivity))
           .addRules(SimpleMarkdownRules.createSimpleMarkdownRules())
 
       SimpleRenderer.render(

--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -18,7 +18,6 @@ import com.discord.simpleast.core.parser.Rule
 import com.discord.simpleast.core.simple.SimpleMarkdownRules
 import com.discord.simpleast.core.simple.SimpleRenderer
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -77,6 +76,7 @@ class MainActivity : AppCompatActivity() {
               this@MainActivity,
               listOf(R.style.Demo_Header_1, R.style.Demo_Header_2, R.style.Demo_Header_3),
               listOf(R.style.Demo_Header_1_Add, R.style.Demo_Header_1_Remove, R.style.Demo_Header_1_Fix)))
+          .addRule(CustomMarkdownRules.createCodeRule(this@MainActivity))
           .addRules(SimpleMarkdownRules.createSimpleMarkdownRules())
 
       SimpleRenderer.render(
@@ -103,6 +103,7 @@ class MainActivity : AppCompatActivity() {
   }
 
   data class RenderContext(val usernameMap: Map<Int, String>)
+
   class UserNode(private val userId: Int) : Node<RenderContext>() {
     override fun render(builder: SpannableStringBuilder, renderContext: RenderContext) {
       builder.append(renderContext.usernameMap[userId] ?: "Invalid User")

--- a/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
@@ -6,7 +6,7 @@ object SampleTexts {
   const val TEXT = """
     Some really long **introduction** text that goes on **__forever__** explaining __something__.
   
-    single newline above
+    single `newline` above. `test` sentence
   """
 
   const val HEADERS = """

--- a/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
@@ -46,6 +46,99 @@ object SampleTexts {
     Still quoted
   """
 
+  private const val CODE_BLOCK_KOTLIN = """
+    Kotlin code block:
+    ```kt
+    object CodeRules {
+      /**
+       * Handles markdown syntax for code blocks for a given language.
+       */
+      val PATTERN_CODE_BLOCK = XXXX
+    
+      private val CODE_BLOCK_LANGUAGE_GROUP = 2
+    
+      @Annotation(test=true)
+      interface CodeLanguageState<Self : CodeLanguageState<Self>> {
+        var codeLangauge: String?  // Inline
+        var isCommentBlock: Boolean
+      }
+      
+      fun <T> foo(t: T): List<Int> {
+        when (t) {
+          is null -> throw Exception("oops!")
+          else -> return listOf(1, 2, 3).let { it }
+        }
+      }
+    }
+    ```
+  """
+
+  private const val CODE_BLOCK_PYTHON = """
+    Python code block:
+    ```py
+    from com.discord import test
+    
+    # This is a python comment!
+    class CodeRules:
+      @Annotation(test=True)
+      def test(x=0, y=False):
+        while (True):
+          if (x is bool):
+            continue
+          else:
+            raise 'oops!' + "I did it again"
+      try:
+        test(456, False)
+      except:
+        lambda lookup: 1 in lookup
+      finally:
+         pass
+    ```
+  """
+
+  private const val CODE_BLOCK_RUST = """
+    Rust code block:
+    ```rs
+    mod test {
+      use std::sync::Arc
+      use crate::{UserId}
+      
+      #[derive(Clone)]
+      pub struct Event {name: A, value: B}
+      
+      impl<T: Clone, V> Event<T, V>
+      where
+        V: Clone + Send + Sync
+      {
+        async fn count(&self, req: T) -> Result<Option<String>, String>{
+          let name = "test";
+          let limit = match req.limit {
+            0 => usize::max_value(),
+            _ => req.limit,
+          }
+          let count = self.count(limit).await?;
+          Ok(Some(count))
+        }
+      }
+    }
+    ```
+  """
+
+  const val CODE_BLOCKS = """
+    # Code block samples
+    inlined:```kt private fun test() {}```
+    inlined:```kt private fun test() {
+      some.call()
+    }```
+    
+    $CODE_BLOCK_KOTLIN
+    $CODE_BLOCK_PYTHON
+    $CODE_BLOCK_RUST
+    
+    That should do it....
+  """
+
+
   const val BENCHMARK_TEXT = """
     Test __Inner **nested** rules__ as well as *look ahead* rules
     ==========
@@ -77,9 +170,8 @@ object SampleTexts {
 
   const val ALL = """
     $TEXT
-    
     $HEADERS
-    
+    $CODE_BLOCKS
     $QUOTES
   """
 }

--- a/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
@@ -124,6 +124,24 @@ object SampleTexts {
     ```
   """
 
+
+  private const val CODE_BLOCK_XML = """
+    XML code block:
+    ```xml
+      <!--
+          Multi-line
+          Commnent
+      -->
+      <resources xmlns:tools="http://schemas.android.com/tools">
+        
+        <attr name="primary_100" format="reference|color" />
+        
+        <!--<editor-fold desc="Android material styles">-->
+        <item name="colorPrimary">@color/black</item>
+      </resources>
+    ```
+  """
+
   const val CODE_BLOCKS = """
     # Code block samples
     inlined:```kt private fun test() {}```
@@ -134,6 +152,7 @@ object SampleTexts {
     $CODE_BLOCK_KOTLIN
     $CODE_BLOCK_PYTHON
     $CODE_BLOCK_RUST
+    $CODE_BLOCK_XML
     
     That should do it....
   """

--- a/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
@@ -73,6 +73,51 @@ object SampleTexts {
     ```
   """
 
+  private const val CODE_BLOCK_PROTO_BUFFERS = """
+    ProtoBuffers code block:
+    ```pb
+    package com.discord.test
+    
+    import "google/protobuf/descriptor.proto";
+
+    extend google.protobuf.MessageOptions {
+      optional int32 my_message_option = 50001;
+    }
+    
+    message MyMessage {
+      option (my_message_option) = 1234;
+    
+      optional string bar = 1 [default = "Test"];
+      oneof qux {
+        option (my_oneof_option) = 42;
+    
+        required string quux = 3;
+      }
+      repeated in64 ids = 4;
+    }
+    
+    enum MyEnum {
+      option (my_enum_option) = true;
+    
+      FOO = 1 [(my_enum_value_option) = 321];
+      BAR = 2;
+    }
+    
+    message RequestType {}
+    message ResponseType {}
+    
+    service MyService {
+      option (my_service_option) = FOO;
+    
+      rpc MyMethod(RequestType) returns(ResponseType) {
+        // Note:  my_method_option has type MyMessage.  We can set each field
+        //   within it using a separate "option" line.
+        option (my_method_option).bar = "Some string";
+      }
+    }
+    ```
+  """
+
   private const val CODE_BLOCK_PYTHON = """
     Python code block:
     ```py
@@ -150,6 +195,7 @@ object SampleTexts {
     }```
     
     $CODE_BLOCK_KOTLIN
+    $CODE_BLOCK_PROTO_BUFFERS
     $CODE_BLOCK_PYTHON
     $CODE_BLOCK_RUST
     $CODE_BLOCK_XML

--- a/app/src/main/java/com/discord/simpleast/sample/spans/BlockBackgroundNode.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/spans/BlockBackgroundNode.kt
@@ -1,0 +1,123 @@
+package com.discord.simpleast.sample.spans
+
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.LeadingMarginSpan
+import android.text.style.LineBackgroundSpan
+import androidx.annotation.ColorInt
+import com.discord.simpleast.core.node.Node
+
+/**
+ * Creates a block background for code sections.
+ */
+class BlockBackgroundNode<R>(
+    private val inQuote: Boolean, vararg children: Node<R>
+): Node.Parent<R>(*children) {
+
+  override fun render(builder: SpannableStringBuilder, renderContext: R) {
+    // Ensure the block we want to append starts on a newline.
+    ensureEndsWithNewline(builder)
+
+    val codeStartIndex = builder.length
+    super.render(builder, renderContext)
+    // BlockBackgroundSpan requires this to function
+    ensureEndsWithNewline(builder)
+
+    val fillColor = Color.DKGRAY
+    val strokeColor = Color.BLACK
+    val backgroundSpan = BlockBackgroundSpan(
+        fillColor, strokeColor,
+        strokeWidth = 2,
+        strokeRadius = 15,
+        leftMargin = if (inQuote) 40 else 0
+    )
+    builder.setSpan(
+        backgroundSpan,
+        codeStartIndex,
+        builder.length,
+        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+    )
+
+    // Apply a leading margin to all lines in the block.
+    val leadingMarginSpan = LeadingMarginSpan.Standard(15)
+    builder.setSpan(
+        leadingMarginSpan,
+        codeStartIndex,
+        builder.length,
+        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+    )
+  }
+
+  private fun ensureEndsWithNewline(builder: SpannableStringBuilder) {
+    if (builder.isNotEmpty()) {
+      val lastChar = CharArray(6)
+      builder.getChars(builder.length - 1, builder.length, lastChar, 0)
+      if (lastChar[0] != '\n') {
+        builder.append('\n')
+      }
+    }
+  }
+}
+
+/**
+ * Computes the position of the paragraph on the screen and draws the desired background.
+ */
+class BlockBackgroundSpan(
+  @ColorInt fillColor: Int,
+  @ColorInt strokeColor: Int,
+  strokeWidth: Int,
+  strokeRadius: Int,
+  val leftMargin: Int
+) : LineBackgroundSpan {
+
+  private val fillPaint = Paint().apply {
+    this.style = Paint.Style.FILL
+    this.color = fillColor
+  }
+
+  private val strokePaint = Paint().apply {
+    this.style = Paint.Style.STROKE
+    this.color = strokeColor
+    this.strokeWidth = strokeWidth.toFloat()
+    this.isAntiAlias = true
+  }
+
+  private val rect = RectF()
+  private val radius = strokeRadius.toFloat()
+
+  fun draw(canvas: Canvas) {
+    canvas.drawRoundRect(rect, radius, radius, fillPaint)
+    canvas.drawRoundRect(rect, radius, radius, strokePaint)
+  }
+
+  override fun drawBackground(
+    canvas: Canvas,
+    paint: Paint,
+    left: Int,
+    right: Int,
+    top: Int,
+    baseline: Int,
+    bottom: Int,
+    text: CharSequence,
+    start: Int,
+    end: Int,
+    lnum: Int
+  ) {
+    if (text !is Spanned) return
+
+    if (text.getSpanStart(this) == start) {
+      rect.left = left.toFloat() + leftMargin
+      rect.top = top.toFloat()
+    }
+
+    if (text.getSpanEnd(this) == end) {
+      rect.right = right.toFloat()
+      rect.bottom = bottom.toFloat()
+      draw(canvas)
+    }
+  }
+}

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,8 @@
 <resources>
+    <!-- Code Language Colors -->
+    <attr name="simpleAST_codeTextAppearance" format="reference" />
+    <attr name="simpleAST_codeCommentAppearance" format="reference" />
+    <attr name="simpleAST_codeKeywordAppearance" format="reference" />
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">

--- a/app/src/main/res/values/styles_code.xml
+++ b/app/src/main/res/values/styles_code.xml
@@ -1,0 +1,38 @@
+<resources>
+    <!-- Code Language Colors -->
+    <style name="Code.TextAppearance" parent="">
+        <item name="android:textSize">10sp</item>
+        <item name="android:textColor">#FFFFFF</item>
+        <item name="android:typeface">monospace</item>
+    </style>
+
+    <style name="Code.TextAppearance.Comment" parent="">
+        <item name="android:textColor">#7A7A7A</item>
+    </style>
+
+    <style name="Code.TextAppearance.Literal" parent="">
+        <item name="android:textColor">#009688</item>
+    </style>
+
+    <style name="Code.TextAppearance.Keyword" parent="">
+        <item name="android:textColor">#E06C75</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="Code.TextAppearance.Identifier" parent="">
+        <item name="android:textColor">#F3CB51</item>
+    </style>
+
+    <style name="Code.TextAppearance.Types" parent="">
+        <item name="android:textColor">#AED581</item>
+    </style>
+
+    <style name="Code.TextAppearance.Generics" parent="">
+        <item name="android:textColor">#63AFEF</item>
+    </style>
+
+    <style name="Code.TextAppearance.Params" parent="">
+        <item name="android:textColor">#C3AEEA</item>
+    </style>
+
+</resources>

--- a/simpleast-core/build.gradle
+++ b/simpleast-core/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 30
         versionCode 28
-        versionName "2.0.0"
+        versionName "2.1.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeNode.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeNode.kt
@@ -1,0 +1,65 @@
+package com.discord.simpleast.code
+
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import com.discord.simpleast.core.node.Node
+import com.discord.simpleast.core.node.StyleNode
+import com.discord.simpleast.core.node.TextNode
+
+@Suppress("EqualsOrHashCode")
+open class CodeNode<RC>(
+    content: Content,
+    @Suppress("unused")
+    private val language: String?,
+    private val stylesProvider: StyleNode.SpanProvider<RC>,
+) : TextNode<RC>(content.body) {
+
+  init {
+    if (content is Content.Parsed<*>) {
+      @Suppress("UNCHECKED_CAST")
+      content.children.forEach { addChild(it as Node<RC>) }
+    }
+  }
+
+  sealed class Content(val body: String) {
+    class Raw(body: String) : Content(body)
+    class Parsed<RC>(raw: String, val children: List<Node<RC>>) : Content(raw)
+  }
+
+  override fun render(builder: SpannableStringBuilder, renderContext: RC) {
+    val styles = stylesProvider.get(renderContext)
+
+    if (hasChildren()) {
+      // In order to apply the styling from this parent node we need to do some span-fu, and
+      // buffer the parsed results into `codeSpan` and then re-insert. This sets the spans from the
+      // parent with the proper priority.
+      val codeSpan = SpannableStringBuilder()
+      styles.forEach {
+        codeSpan.setSpan(it, 0, 0, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
+      }
+      // First render all child nodes, as these are the nodes we want to apply the styles to.
+      getChildren()?.forEach { it.render(codeSpan, renderContext) }
+      builder.append('\u200A')  // HACK: use space to terminate span
+      builder.insert(builder.length - 1, codeSpan)
+    } else {
+      val startIndex = builder.length
+      builder.append(content)
+      styles.forEach {
+        builder.setSpan(it, startIndex, builder.length, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
+      }
+    }
+  }
+
+  override fun equals(other: Any?): Boolean = other is CodeNode<*> &&
+      other.language == this.language &&
+      other.content == this.content
+
+  class DefinitionNode<RC>(
+      pre: String, name: String,
+      codeStyleProviders: CodeStyleProviders<RC>
+  ) : Node.Parent<RC>(
+      StyleNode.Text(pre, codeStyleProviders.keywordStyleProvider),
+      StyleNode.Text(name, codeStyleProviders.typesStyleProvider)
+  )
+}
+

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeNode.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeNode.kt
@@ -58,8 +58,8 @@ open class CodeNode<RC>(
       pre: String, name: String,
       codeStyleProviders: CodeStyleProviders<RC>
   ) : Node.Parent<RC>(
-      StyleNode.Text(pre, codeStyleProviders.keywordStyleProvider),
-      StyleNode.Text(name, codeStyleProviders.typesStyleProvider)
+      StyleNode.TextStyledNode(pre, codeStyleProviders.keywordStyleProvider),
+      StyleNode.TextStyledNode(name, codeStyleProviders.typesStyleProvider)
   )
 }
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -249,7 +249,7 @@ object CodeRules {
   ): Rule<R, Node<R>, S> {
     return object : Rule<R, Node<R>, S>(PATTERN_CODE_INLINE) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S)
-          : ParseSpec<R, Node<R>, S> {
+          : ParseSpec<R, S> {
         val codeBody = matcher.group(1).orEmpty()
 
         val content = CodeNode.Content.Raw(codeBody)

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -74,7 +74,7 @@ object CodeRules {
         ): ParseSpec<R, S> {
           val content = matcher.group(group).orEmpty()
           val node = stylesProvider
-              ?.let { StyleNode.Text(content, it) }
+              ?.let { StyleNode.TextStyledNode(content, it) }
               ?: TextNode(content)
           return ParseSpec.createTerminal(node, state)
         }

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -59,14 +59,15 @@ object CodeRules {
   internal fun createWordPattern(vararg words: String) =
       Pattern.compile("""^\b(?:${words.joinToString("|")})\b""")
 
-  fun <R, S> Pattern.toFullMatchRule(
+  fun <R, S> Pattern.toMatchGroupRule(
+      group: Int = 0,
       stylesProvider: StyleNode.SpanProvider<R>? = null
   ) =
       object : Rule<R, Node<R>, S>(this) {
         override fun parse(
             matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S
         ): ParseSpec<R, S> {
-          val content = matcher.group()
+          val content = matcher.group(group).orEmpty()
           val node = stylesProvider
               ?.let { StyleNode.Text(content, it) }
               ?: TextNode(content)
@@ -101,13 +102,13 @@ object CodeRules {
         codeStyleProviders,
         additionalRules = listOf(
             createSingleLineCommentPattern("#")
-                .toFullMatchRule(codeStyleProviders.commentStyleProvider),
+                .toMatchGroupRule(stylesProvider = codeStyleProviders.commentStyleProvider),
             Pattern.compile("""^"[\s\S]*?(?<!\\)"(?=\W|\s|$)""")
-                    .toFullMatchRule(codeStyleProviders.literalStyleProvider),
+                    .toMatchGroupRule(stylesProvider = codeStyleProviders.literalStyleProvider),
             Pattern.compile("""^'[\s\S]*?(?<!\\)'(?=\W|\s|$)""")
-                    .toFullMatchRule(codeStyleProviders.literalStyleProvider),
+                    .toMatchGroupRule(stylesProvider = codeStyleProviders.literalStyleProvider),
             Pattern.compile("""^@(\w+)""")
-                .toFullMatchRule(codeStyleProviders.genericsStyleProvider)),
+                .toMatchGroupRule(stylesProvider = codeStyleProviders.genericsStyleProvider)),
         definitions = arrayOf("class", "def", "lambda"),
         builtIns = arrayOf("True|False|None"),
         "from|import|global|nonlocal",
@@ -122,11 +123,11 @@ object CodeRules {
         codeStyleProviders,
         additionalRules = listOf(
             createSingleLineCommentPattern("//")
-                .toFullMatchRule(codeStyleProviders.commentStyleProvider),
+                .toMatchGroupRule(stylesProvider = codeStyleProviders.commentStyleProvider),
             Pattern.compile("""^"[\s\S]*?(?<!\\)"(?=\W|\s|$)""")
-                .toFullMatchRule(codeStyleProviders.literalStyleProvider),
+                .toMatchGroupRule(stylesProvider = codeStyleProviders.literalStyleProvider),
             Pattern.compile("""^#!?\[.*?\]\n""")
-                .toFullMatchRule(codeStyleProviders.genericsStyleProvider)),
+                .toMatchGroupRule(stylesProvider = codeStyleProviders.genericsStyleProvider)),
         definitions = arrayOf("struct", "trait", "mod"),
         builtIns = arrayOf(
             "Self|Result|Ok|Err|Option|None|Some",
@@ -143,10 +144,10 @@ object CodeRules {
 
     val xmlRules = listOf<Rule<R, Node<R>, S>>(
         Xml.PATTERN_XML_COMMENT
-            .toFullMatchRule(codeStyleProviders.commentStyleProvider),
+            .toMatchGroupRule(stylesProvider = codeStyleProviders.commentStyleProvider),
         Xml.createTagRule(codeStyleProviders),
-        PATTERN_LEADING_WS_CONSUMER.toFullMatchRule(),
-        PATTERN_TEXT.toFullMatchRule(),
+        PATTERN_LEADING_WS_CONSUMER.toMatchGroupRule(),
+        PATTERN_TEXT.toMatchGroupRule(),
     )
 
     return mapOf(
@@ -175,11 +176,11 @@ object CodeRules {
       additionalRules +
           listOf(
               createDefinitionRule(codeStyleProviders, *definitions),
-              createWordPattern(*builtIns).toFullMatchRule(codeStyleProviders.genericsStyleProvider),
-              createWordPattern(*keywords).toFullMatchRule(codeStyleProviders.keywordStyleProvider),
-              PATTERN_NUMBERS.toFullMatchRule(codeStyleProviders.literalStyleProvider),
-              PATTERN_LEADING_WS_CONSUMER.toFullMatchRule(),
-              PATTERN_TEXT.toFullMatchRule(),
+              createWordPattern(*builtIns).toMatchGroupRule(stylesProvider = codeStyleProviders.genericsStyleProvider),
+              createWordPattern(*keywords).toMatchGroupRule(stylesProvider = codeStyleProviders.keywordStyleProvider),
+              PATTERN_NUMBERS.toMatchGroupRule(stylesProvider = codeStyleProviders.literalStyleProvider),
+              PATTERN_LEADING_WS_CONSUMER.toMatchGroupRule(),
+              PATTERN_TEXT.toMatchGroupRule(),
           )
 
   /**

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -1,0 +1,207 @@
+package com.discord.simpleast.code
+
+import com.discord.simpleast.core.node.Node
+import com.discord.simpleast.core.node.StyleNode
+import com.discord.simpleast.core.node.TextNode
+import com.discord.simpleast.core.parser.ParseSpec
+import com.discord.simpleast.core.parser.Parser
+import com.discord.simpleast.core.parser.Rule
+import com.discord.simpleast.core.simple.SimpleMarkdownRules
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+/**
+ * Support for full markdown representations.
+ *
+ * @see com.discord.simpleast.core.simple.SimpleMarkdownRules
+ */
+@Suppress("MemberVisibilityCanBePrivate")
+object CodeRules {
+  /**
+   * Handles markdown syntax for code blocks for a given language.
+   *
+   * Examples:
+   * inlined ```kt fun test()```
+   * inlined2 ```kt
+   * fun test()
+   * ```
+   *
+   * ```kotlin
+   * class Test: Runnable {
+   *   override fun run() {
+   *     val x = new BigInt(5)
+   *   }
+   * }
+   * ```
+   */
+  val PATTERN_CODE_BLOCK: Pattern =
+      Pattern.compile("""^```(?:([A-z0-9_+\-.]+))?(\s*)([^\n].*?)\n*```""", Pattern.DOTALL)
+
+  private const val CODE_BLOCK_LANGUAGE_GROUP = 1
+  private const val CODE_BLOCK_WS_PREFIX = 2
+  private const val CODE_BLOCK_BODY_GROUP = 3
+
+  /**
+   * This is needed to simplify the other rule parsers to only need a leading pattern match.
+   * We also don't want to remove extraneous newlines/ws like what the [SimpleMarkdownRules.createNewlineRule] does.
+   */
+  val PATTERN_LEADING_WS_CONSUMER: Pattern = Pattern.compile("""^(?:\n\s*)+""")
+
+  /**
+   * This is needed to simplify the other rule parsers to only need a leading pattern match.
+   * The pattern splits on each token (symbol/word) unlike [SimpleMarkdownRules.createTextRule] which merges
+   * symbols and words until another symbol is reached.
+   */
+  val PATTERN_TEXT: Pattern = Pattern.compile("""^[\s\S]+?(?=\b|[^0-9A-Za-z\s\u00c0-\uffff]|\n| {2,}\n|\w+:\S|$)""")
+
+  val PATTERN_NUMBERS: Pattern = Pattern.compile("""^\b\d+?\b""")
+
+  internal fun createWordPattern(vararg words: String) =
+      Pattern.compile("""^\b(?:${words.joinToString("|")})\b""")
+
+  fun <R, S> Pattern.toFullMatchRule(
+      stylesProvider: StyleNode.SpanProvider<R>? = null
+  ) =
+      object : Rule<R, Node<R>, S>(this) {
+        override fun parse(
+            matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S
+        ): ParseSpec<R, S> {
+          val content = matcher.group()
+          val node = stylesProvider
+              ?.let { StyleNode.Text(content, it) }
+              ?: TextNode(content)
+          return ParseSpec.createTerminal(node, state)
+        }
+      }
+
+  fun <R, S> createDefinitionRule(
+      codeStyleProviders: CodeStyleProviders<R>, vararg identifiers: String) =
+      object : Rule<R, Node<R>, S>(Pattern.compile("""^\b(${identifiers.joinToString("|")})(\s+\w+)""")) {
+        override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S): ParseSpec<R, S> {
+          val definition = matcher.group(1)!!
+          val signature = matcher.group(2)!!
+          return ParseSpec.createTerminal(
+              CodeNode.DefinitionNode(definition, signature, codeStyleProviders),
+              state)
+        }
+      }
+
+  fun <R, S> createCodeLanguageMap(codeStyleProviders: CodeStyleProviders<R>)
+      : Map<String, List<Rule<R, Node<R>, S>>> {
+
+    val kotlinRules = createGenericCodeRules<R, S>(
+        codeStyleProviders,
+        additionalRules = Kotlin.createKotlinCodeRules(codeStyleProviders),
+        definitions = arrayOf("object", "class", "interface"),
+        builtIns = Kotlin.BUILT_INS,
+        keywords = Kotlin.KEYWORDS)
+
+
+    val pythonRules = createGenericCodeRules<R, S>(
+        codeStyleProviders,
+        additionalRules = listOf(
+            createSingleLineCommentPattern("#")
+                .toFullMatchRule(codeStyleProviders.commentStyleProvider),
+            Pattern.compile("""^"[\s\S]*?(?<!\\)"(?=\W|\s|$)""")
+                    .toFullMatchRule(codeStyleProviders.literalStyleProvider),
+            Pattern.compile("""^'[\s\S]*?(?<!\\)'(?=\W|\s|$)""")
+                    .toFullMatchRule(codeStyleProviders.literalStyleProvider),
+            Pattern.compile("""^@(\w+)""")
+                .toFullMatchRule(codeStyleProviders.genericsStyleProvider)),
+        definitions = arrayOf("class", "def", "lambda"),
+        builtIns = arrayOf("True|False|None"),
+        "from|import|global|nonlocal",
+        "async|await|class|self|cls|def|lambda",
+        "for|while|if|else|elif|break|continue|return",
+        "try|except|finally|raise|pass|yeild",
+        "in|as|is|del",
+        "and|or|not|assert",
+    )
+
+    val rustRules = createGenericCodeRules<R, S>(
+        codeStyleProviders,
+        additionalRules = listOf(
+            createSingleLineCommentPattern("//")
+                .toFullMatchRule(codeStyleProviders.commentStyleProvider),
+            Pattern.compile("""^"[\s\S]*?(?<!\\)"(?=\W|\s|$)""")
+                .toFullMatchRule(codeStyleProviders.literalStyleProvider),
+            Pattern.compile("""^#!?\[.*?\]\n""")
+                .toFullMatchRule(codeStyleProviders.genericsStyleProvider)),
+        definitions = arrayOf("struct", "trait", "mod"),
+        builtIns = arrayOf(
+            "Self|Result|Ok|Err|Option|None|Some",
+            "Copy|Clone|Eq|Hash|Send|Sync|Sized|Debug|Display",
+            "Arc|Rc|Box|Pin|Future",
+            "true|false|bool|usize|i64|u64|u32|i32|str|String"
+        ),
+        "let|mut|static|const|unsafe",
+        "crate|mod|extern|pub|pub(super)|use",
+        "struct|enum|trait|type|where|impl|dyn|async|await|move|self|fn",
+        "for|while|loop|if|else|match|break|continue|return|try",
+        "in|as|ref",
+    )
+
+    return mapOf(
+        "kt" to kotlinRules,
+        "kotlin" to kotlinRules,
+
+        "py" to pythonRules,
+        "python" to pythonRules,
+
+        "rs" to rustRules,
+        "rust" to rustRules,
+    )
+  }
+
+  private fun createSingleLineCommentPattern(prefix: String) =
+      Pattern.compile("""^(?:$prefix.*?(?=\n|$))""")
+
+  private fun <R, S> createGenericCodeRules(
+      codeStyleProviders: CodeStyleProviders<R>,
+      additionalRules: List<Rule<R, Node<R>, S>>,
+      definitions: Array<String>, builtIns: Array<String>, vararg keywords: String
+  ): List<Rule<R, Node<R>, S>> =
+      additionalRules +
+          listOf(
+              createDefinitionRule(codeStyleProviders, *definitions),
+              createWordPattern(*builtIns).toFullMatchRule(codeStyleProviders.genericsStyleProvider),
+              createWordPattern(*keywords).toFullMatchRule(codeStyleProviders.keywordStyleProvider),
+              PATTERN_NUMBERS.toFullMatchRule(codeStyleProviders.literalStyleProvider),
+              PATTERN_LEADING_WS_CONSUMER.toFullMatchRule(),
+              PATTERN_TEXT.toFullMatchRule(),
+          )
+
+  /**
+   * @param textStyleProvider appearance of the text inside the block
+   * @param languageMap maps language identifer to a list of rules to parse the syntax
+   * @param wrapperNodeProvider set if you want to provide additional styling on the code representation.
+   *    Useful for setting code blocks backgrounds.
+   */
+  fun <R, S> createCodeRule(
+      textStyleProvider: StyleNode.SpanProvider<R>,
+      languageMap: Map<String, List<Rule<R, Node<R>, S>>>,
+      wrapperNodeProvider: (CodeNode<R>, Boolean, S) -> Node<R> =
+          @Suppress("UNUSED_ANONYMOUS_PARAMETER")
+          { codeNode, startsWithNewline, state -> codeNode }
+  ): Rule<R, Node<R>, S> {
+    return object : Rule<R, Node<R>, S>(PATTERN_CODE_BLOCK) {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S)
+          : ParseSpec<R, S> {
+        val language = matcher.group(CODE_BLOCK_LANGUAGE_GROUP)
+        val codeBody = matcher.group(CODE_BLOCK_BODY_GROUP).orEmpty()
+        val startsWithNewline = matcher.group(CODE_BLOCK_WS_PREFIX)!!.contains('\n')
+
+        val languageRules = language?.let { languageMap[it] }
+
+        val content = languageRules?.let {
+          @Suppress("UNCHECKED_CAST")
+          val children = parser.parse(codeBody, state, languageRules) as List<Node<R>>
+          CodeNode.Content.Parsed(codeBody, children)
+        } ?: CodeNode.Content.Raw(codeBody)
+
+        val codeNode = CodeNode(content, language, textStyleProvider)
+        return ParseSpec.createTerminal(wrapperNodeProvider(codeNode, startsWithNewline, state), state)
+      }
+    }
+  }
+}

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -141,6 +141,14 @@ object CodeRules {
         "in|as|ref",
     )
 
+    val xmlRules = listOf<Rule<R, Node<R>, S>>(
+        Xml.PATTERN_XML_COMMENT
+            .toFullMatchRule(codeStyleProviders.commentStyleProvider),
+        Xml.createTagRule(codeStyleProviders),
+        PATTERN_LEADING_WS_CONSUMER.toFullMatchRule(),
+        PATTERN_TEXT.toFullMatchRule(),
+    )
+
     return mapOf(
         "kt" to kotlinRules,
         "kotlin" to kotlinRules,
@@ -150,6 +158,9 @@ object CodeRules {
 
         "rs" to rustRules,
         "rust" to rustRules,
+
+        "xml" to xmlRules,
+        "http" to xmlRules,
     )
   }
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -102,6 +102,22 @@ object CodeRules {
         builtIns = Kotlin.BUILT_INS,
         keywords = Kotlin.KEYWORDS)
 
+    val protoRules = createGenericCodeRules<R, S>(
+        codeStyleProviders,
+        additionalRules = listOf(
+            createSingleLineCommentPattern("//")
+                .toMatchGroupRule(stylesProvider = codeStyleProviders.commentStyleProvider),
+            Pattern.compile("""^"[\s\S]*?(?<!\\)"(?=\W|\s|$)""")
+                .toMatchGroupRule(stylesProvider = codeStyleProviders.literalStyleProvider),
+        ),
+        definitions = arrayOf("message|enum|extend|service"),
+        builtIns = arrayOf("true|false",
+            "string|bool|double|float|bytes",
+            "int32|uint32|sint32|int64|unit64|sint64",
+            "map"),
+        "required|repeated|optional|option|oneof|default|reserved",
+        "package|import",
+        "rpc|returns")
 
     val pythonRules = createGenericCodeRules<R, S>(
         codeStyleProviders,
@@ -158,6 +174,10 @@ object CodeRules {
     return mapOf(
         "kt" to kotlinRules,
         "kotlin" to kotlinRules,
+
+        "protobuf" to protoRules,
+        "proto" to protoRules,
+        "pb" to protoRules,
 
         "py" to pythonRules,
         "python" to pythonRules,

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeStyleProviders.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeStyleProviders.kt
@@ -1,0 +1,16 @@
+package com.discord.simpleast.code
+
+import com.discord.simpleast.core.node.StyleNode
+
+data class CodeStyleProviders<R>(
+    val defaultStyleProvider: StyleNode.SpanProvider<R> = emptyProvider(),
+    val commentStyleProvider: StyleNode.SpanProvider<R> = emptyProvider(),
+    val literalStyleProvider: StyleNode.SpanProvider<R> = emptyProvider(),
+    val keywordStyleProvider: StyleNode.SpanProvider<R> = emptyProvider(),
+    val identifierStyleProvider: StyleNode.SpanProvider<R> = emptyProvider(),
+    val typesStyleProvider: StyleNode.SpanProvider<R> = emptyProvider(),
+    val genericsStyleProvider: StyleNode.SpanProvider<R> = emptyProvider(),
+    val paramsStyleProvider: StyleNode.SpanProvider<R> = emptyProvider(),
+)
+
+private fun <R> emptyProvider() = StyleNode.SpanProvider<R> { emptyList<Any>() }

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/Kotlin.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/Kotlin.kt
@@ -1,6 +1,6 @@
 package com.discord.simpleast.code
 
-import com.discord.simpleast.code.CodeRules.toFullMatchRule
+import com.discord.simpleast.code.CodeRules.toMatchGroupRule
 import com.discord.simpleast.core.node.Node
 import com.discord.simpleast.core.node.StyleNode
 import com.discord.simpleast.core.parser.ParseSpec
@@ -134,9 +134,9 @@ object Kotlin {
       codeStyleProviders: CodeStyleProviders<RC>
   ): List<Rule<RC, Node<RC>, S>> =
       listOf(
-          PATTERN_KOTLIN_COMMENTS.toFullMatchRule(codeStyleProviders.commentStyleProvider),
-          PATTERN_KOTLIN_STRINGS.toFullMatchRule(codeStyleProviders.literalStyleProvider),
-          PATTERN_KOTLIN_ANNOTATION.toFullMatchRule(codeStyleProviders.genericsStyleProvider),
+          PATTERN_KOTLIN_COMMENTS.toMatchGroupRule(stylesProvider = codeStyleProviders.commentStyleProvider),
+          PATTERN_KOTLIN_STRINGS.toMatchGroupRule(stylesProvider = codeStyleProviders.literalStyleProvider),
+          PATTERN_KOTLIN_ANNOTATION.toMatchGroupRule(stylesProvider = codeStyleProviders.genericsStyleProvider),
           FieldNode.createFieldRule(codeStyleProviders),
           FunctionNode.createFunctionRule(codeStyleProviders),
       )

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/Kotlin.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/Kotlin.kt
@@ -1,0 +1,143 @@
+package com.discord.simpleast.code
+
+import com.discord.simpleast.code.CodeRules.toFullMatchRule
+import com.discord.simpleast.core.node.Node
+import com.discord.simpleast.core.node.StyleNode
+import com.discord.simpleast.core.parser.ParseSpec
+import com.discord.simpleast.core.parser.Parser
+import com.discord.simpleast.core.parser.Rule
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+/**
+ * Support for full syntax highlighting in kotlin
+ *
+ * @see CodeRules
+ */
+object Kotlin {
+
+  val KEYWORDS: Array<String> = arrayOf(
+      "public|private|internal|inline|lateinit|abstract|open|reified",
+      "import|package",
+      "class|interface|data|enum|sealed|object|typealias",
+      "fun|override|this|super|where|constructor|init|param|delegate",
+      "const|val|var|get|final|vararg|it",
+      "return|break|continue|suspend",
+      "for|while|do|if|else|when|try|catch|finally|throw",
+      "in|out|is|as|typeof",
+      "shr|ushr|shl|ushl",
+      "true|false|null"
+  )
+
+  val BUILT_INS = arrayOf("true|false|Boolean|String|Char",
+      "Int|UInt|Long|ULong|Float|Double|Byte|UByte|Short|UShort",
+      "Self|Set|Map|MutableMap|List|MutableList|Array|Runnable|Unit",
+      "arrayOf|listOf|mapOf|setOf|let|also|apply|run",
+  )
+
+  class FunctionNode<RC>(
+      pre: String, generic: String?, signature: String, params: String,
+      codeStyleProviders: CodeStyleProviders<RC>
+  ) : Node.Parent<RC>(
+      StyleNode.Text(pre, codeStyleProviders.keywordStyleProvider),
+      generic?.let { StyleNode.Text(it, codeStyleProviders.genericsStyleProvider) },
+      StyleNode.Text(signature, codeStyleProviders.identifierStyleProvider),
+      StyleNode.Text(params, codeStyleProviders.paramsStyleProvider),
+  ) {
+    companion object {
+
+      /**
+       * Matches against a kotlin function declaration
+       *
+       * ```
+       * fun <T> foo(x: T)
+       * fun createPoint(x: Int, y: Int)
+       * ```
+       */
+      private val PATTERN_KOTLIN_FUNC =
+          """^(fun)( *<.*>)?( \w+)( *\(.*?\))""".toRegex(RegexOption.DOT_MATCHES_ALL).toPattern()
+
+      fun <RC, S> createFunctionRule(codeStyleProviders: CodeStyleProviders<RC>) =
+          object : Rule<RC, Node<RC>, S>(PATTERN_KOTLIN_FUNC) {
+            override fun parse(matcher: Matcher, parser: Parser<RC, in Node<RC>, S>, state: S): ParseSpec<RC, S> {
+              val definition = matcher.group(1)
+              val generic = matcher.group(2)
+              val signature = matcher.group(3)
+              val params = matcher.group(4)
+              return ParseSpec.createTerminal(FunctionNode(definition!!, generic, signature!!, params!!, codeStyleProviders), state)
+            }
+          }
+    }
+  }
+
+  class FieldNode<RC>(
+      definition: String, name: String,
+      codeStyleProviders: CodeStyleProviders<RC>
+  ) : Node.Parent<RC>(
+      StyleNode.Text(definition, codeStyleProviders.keywordStyleProvider),
+      StyleNode.Text(name, codeStyleProviders.identifierStyleProvider),
+  ) {
+    companion object {
+      /**
+       * Matches against a kotlin field definitions
+       *
+       * ```
+       * val x = 1
+       * val p: Point = Point(1,2)
+       * ```
+       */
+      private val PATTERN_KOTLIN_FIELD =
+          Pattern.compile("""^(val|var)(\s+\w+)""", Pattern.DOTALL)
+
+      fun <RC, S> createFieldRule(
+          codeStyleProviders: CodeStyleProviders<RC>
+      ) =
+          object : Rule<RC, Node<RC>, S>(PATTERN_KOTLIN_FIELD) {
+            override fun parse(matcher: Matcher, parser: Parser<RC, in Node<RC>, S>, state: S):
+                ParseSpec<RC, S> {
+              val definition = matcher.group(1)
+              val name = matcher.group(2)
+              return ParseSpec.createTerminal(
+                  FieldNode(definition!!, name!!, codeStyleProviders), state)
+            }
+          }
+    }
+  }
+
+  private val PATTERN_KOTLIN_COMMENTS =
+      Pattern.compile("""^(?:(?://.*?(?=\n|$))|(/\*.*?\*/))""", Pattern.DOTALL)
+
+  /**
+   * Matches against a kotlin annotations
+   *
+   * ```
+   * @Annotation
+   * ```
+   */
+  private val PATTERN_KOTLIN_ANNOTATION =
+      Pattern.compile("""^@(\w+)""")
+
+  /**
+   * Matches against a kotlin string
+   *
+   * ```kt
+   * call("hello")
+   * """
+   * hello world
+   * """
+   * ```
+   */
+  private val PATTERN_KOTLIN_STRINGS =
+      Pattern.compile("""^"[\s\S]*?(?<!\\)"(?=\W|\s|$)""")
+
+  internal fun <RC, S> createKotlinCodeRules(
+      codeStyleProviders: CodeStyleProviders<RC>
+  ): List<Rule<RC, Node<RC>, S>> =
+      listOf(
+          PATTERN_KOTLIN_COMMENTS.toFullMatchRule(codeStyleProviders.commentStyleProvider),
+          PATTERN_KOTLIN_STRINGS.toFullMatchRule(codeStyleProviders.literalStyleProvider),
+          PATTERN_KOTLIN_ANNOTATION.toFullMatchRule(codeStyleProviders.genericsStyleProvider),
+          FieldNode.createFieldRule(codeStyleProviders),
+          FunctionNode.createFunctionRule(codeStyleProviders),
+      )
+}

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/Kotlin.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/Kotlin.kt
@@ -39,10 +39,10 @@ object Kotlin {
       pre: String, generic: String?, signature: String, params: String,
       codeStyleProviders: CodeStyleProviders<RC>
   ) : Node.Parent<RC>(
-      StyleNode.Text(pre, codeStyleProviders.keywordStyleProvider),
-      generic?.let { StyleNode.Text(it, codeStyleProviders.genericsStyleProvider) },
-      StyleNode.Text(signature, codeStyleProviders.identifierStyleProvider),
-      StyleNode.Text(params, codeStyleProviders.paramsStyleProvider),
+      StyleNode.TextStyledNode(pre, codeStyleProviders.keywordStyleProvider),
+      generic?.let { StyleNode.TextStyledNode(it, codeStyleProviders.genericsStyleProvider) },
+      StyleNode.TextStyledNode(signature, codeStyleProviders.identifierStyleProvider),
+      StyleNode.TextStyledNode(params, codeStyleProviders.paramsStyleProvider),
   ) {
     companion object {
 
@@ -74,8 +74,8 @@ object Kotlin {
       definition: String, name: String,
       codeStyleProviders: CodeStyleProviders<RC>
   ) : Node.Parent<RC>(
-      StyleNode.Text(definition, codeStyleProviders.keywordStyleProvider),
-      StyleNode.Text(name, codeStyleProviders.identifierStyleProvider),
+      StyleNode.TextStyledNode(definition, codeStyleProviders.keywordStyleProvider),
+      StyleNode.TextStyledNode(name, codeStyleProviders.identifierStyleProvider),
   ) {
     companion object {
       /**

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/Xml.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/Xml.kt
@@ -1,0 +1,83 @@
+package com.discord.simpleast.code
+
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import com.discord.simpleast.core.node.Node
+import com.discord.simpleast.core.parser.ParseSpec
+import com.discord.simpleast.core.parser.Parser
+import com.discord.simpleast.core.parser.Rule
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+
+object Xml {
+  val PATTERN_XML_COMMENT: Pattern = Pattern.compile("""^<!--[\s\S]*?-->""", Pattern.DOTALL)
+
+  val PATTERN_XML_TAG: Pattern = Pattern.compile(
+      """^<([\s\S]+?)(?:>(.*?)<\/([\s\S]+?))?>""", Pattern.DOTALL)
+  const val PATTERN_XML_TAG_OPENING_GROUP = 1
+  const val PATTERN_XML_TAG_CONTENT_GROUP = 2
+  const val PATTERN_XML_TAG_CLOSING_GROUP = 3
+
+  class TagNode<RC>(
+      val opening: String, val closing: String?,
+      private val codeStyleProviders: CodeStyleProviders<RC>
+  ) : Node.Parent<RC>() {
+    override fun render(builder: SpannableStringBuilder, renderContext: RC) {
+      val (name, remainder) =
+          when (val index = opening.indexOfFirst { it.isWhitespace() || it == '/' }) {
+            -1 -> opening to ""
+            else -> opening.substring(0, index) to opening.substring(index)
+          }
+      val typeStylesProvider = codeStyleProviders.genericsStyleProvider::get
+
+      var startIndex = builder.length
+      builder.append("<$name")
+      typeStylesProvider(renderContext).forEach {
+        builder.setSpan(it, startIndex, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      }
+
+      startIndex = builder.length
+      builder.append("$remainder>")
+      codeStyleProviders.paramsStyleProvider.get(renderContext).forEach {
+        builder.setSpan(it, startIndex, builder.length - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      }
+      typeStylesProvider(renderContext).forEach {
+        builder.setSpan(it, builder.length - 1, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+      }
+
+      super.render(builder, renderContext)
+
+      if (!closing.isNullOrEmpty()) {
+        startIndex = builder.length
+        builder.append("</$closing>")
+        typeStylesProvider(renderContext).forEach {
+          builder.setSpan(it, startIndex + 1, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+      }
+    }
+  }
+
+  fun <RC, S> createTagRule(
+      codeStyleProviders: CodeStyleProviders<RC>
+  ) =
+      object : Rule<RC, Node<RC>, S>(PATTERN_XML_TAG) {
+        override fun parse(matcher: Matcher, parser: Parser<RC, in Node<RC>, S>, state: S):
+            ParseSpec<RC, S> {
+          val opening = matcher.group(PATTERN_XML_TAG_OPENING_GROUP)!!
+          val closing = matcher.group(PATTERN_XML_TAG_CLOSING_GROUP)
+
+          return if (matcher.group(PATTERN_XML_TAG_CONTENT_GROUP) != null) {
+            ParseSpec.createNonterminal(
+                TagNode(opening, closing, codeStyleProviders),
+                state,
+                matcher.start(PATTERN_XML_TAG_CONTENT_GROUP),
+                matcher.end(PATTERN_XML_TAG_CONTENT_GROUP))
+          } else {
+            ParseSpec.createTerminal(
+                TagNode(opening, closing, codeStyleProviders),
+                state)
+          }
+        }
+      }
+}

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/node/Node.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/node/Node.kt
@@ -7,9 +7,7 @@ import android.text.SpannableStringBuilder
  *
  * @param R The render context, can be any object that holds what's required for rendering. See [render].
  */
-open class Node<R> {
-
-  private var children: MutableCollection<Node<R>>? = null
+open class Node<R>(private var children: MutableCollection<Node<R>>? = null) {
 
   fun getChildren(): Collection<Node<R>>? = children
 
@@ -22,4 +20,18 @@ open class Node<R> {
   }
 
   open fun render(builder: SpannableStringBuilder, renderContext: R) {}
+
+  /**
+   * Wrapper around [Node] which simply renders all children.
+   */
+  open class Parent<R>(vararg children: Node<R>?) : Node<R>(children.mapNotNull { it }.toMutableList()) {
+    override fun render(builder: SpannableStringBuilder, renderContext: R) {
+      getChildren()?.forEach { it.render(builder, renderContext) }
+    }
+
+    override fun toString() = "${javaClass.simpleName} >\n" +
+      getChildren()?.joinToString("\n->", prefix = ">>", postfix = "\n>|") {
+        it.toString()
+      }
+  }
 }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/node/StyleNode.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/node/StyleNode.kt
@@ -9,24 +9,39 @@ import org.jetbrains.annotations.TestOnly
  * @param RC RenderContext
  * @param T Type of Span to apply
  */
-open class StyleNode<RC, T>(val styles: List<T>) : Node<RC>() {
+open class StyleNode<RC, T>(val styles: List<T>) : Node.Parent<RC>() {
 
   override fun render(builder: SpannableStringBuilder, renderContext: RC) {
     val startIndex = builder.length
 
     // First render all child nodes, as these are the nodes we want to apply the styles to.
-    getChildren()?.forEach { it.render(builder, renderContext) }
+    super.render(builder, renderContext)
 
     styles.forEach { builder.setSpan(it, startIndex, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) }
   }
 
-  override fun toString() = "${javaClass.simpleName} >\n" +
-      getChildren()?.joinToString("\n->", prefix = ">>", postfix = "\n>|") {
-        it.toString()
+  fun interface SpanProvider<RC> {
+    fun get(renderContext: RC) : Iterable<*>
+  }
+
+  /**
+   * A slightly optimized version of styling text in a terminal fashion.
+   * Use this if you know the node is terminal and will have no children as it will not render them.
+   *
+   * @see TextNode
+   */
+  class Text<RC>(content: String, val stylesProvider: SpanProvider<RC>) : TextNode<RC>(content) {
+    override fun render(builder: SpannableStringBuilder, renderContext: RC) {
+      val startIndex = builder.length
+      super.render(builder, renderContext)
+
+      stylesProvider.get(renderContext).forEach {
+        builder.setSpan(it, startIndex, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
       }
+    }
+  }
 
   companion object {
-
     /**
      * Convenience method for creating a [StyleNode] when we already know what
      * the text content will be.

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/node/StyleNode.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/node/StyleNode.kt
@@ -30,7 +30,7 @@ open class StyleNode<RC, T>(val styles: List<T>) : Node.Parent<RC>() {
    *
    * @see TextNode
    */
-  class Text<RC>(content: String, val stylesProvider: SpanProvider<RC>) : TextNode<RC>(content) {
+  class TextStyledNode<RC>(content: String, val stylesProvider: SpanProvider<RC>) : TextNode<RC>(content) {
     override fun render(builder: SpannableStringBuilder, renderContext: RC) {
       val startIndex = builder.length
       super.render(builder, renderContext)

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/node/TextNode.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/node/TextNode.kt
@@ -11,5 +11,5 @@ open class TextNode<R> (val content: String) : Node<R>() {
     builder.append(content)
   }
 
-  override fun toString() = "${javaClass.simpleName}[${getChildren()?.size}]: $content"
+  override fun toString() = "${javaClass.simpleName}: $content"
 }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
@@ -9,6 +9,7 @@ import java.util.*
  * @param R The render context, can be any object that holds what's required for rendering.
  *          See [Node.render]
  * @param T The type of nodes that are handled.
+ * @param S The state of the current parser.
  */
 open class Parser<R, T : Node<R>, S> @JvmOverloads constructor(private val enableDebugging: Boolean = false) {
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
@@ -131,7 +131,7 @@ object MarkdownRules {
                                                protected val innerRules: List<Rule<RC, Node<RC>, S>>) :
       MarkdownRules.HeaderLineRule<RC, S>(PATTERN_HEADER_ITEM_ALT_CLASSED, styleSpanProvider) {
 
-    constructor(styleSpanProvider: (Int) -> CharacterStyle, classSpanProvider: (String) -> T?) :
+      constructor(styleSpanProvider: (Int) -> CharacterStyle, classSpanProvider: (String) -> T?) :
         this(styleSpanProvider, classSpanProvider,
             SimpleMarkdownRules.createSimpleMarkdownRules<RC, S>(false)
                 + SimpleMarkdownRules.createTextRule())

--- a/simpleast-core/src/test/java/com/discord/simpleast/ASTTestingUtils.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/ASTTestingUtils.kt
@@ -1,0 +1,39 @@
+package com.discord.simpleast
+
+import com.discord.simpleast.core.node.Node
+import com.discord.simpleast.core.node.TextNode
+import com.discord.simpleast.core.utils.ASTUtils
+import org.junit.Assert
+
+
+fun Node<*>.assertItemText(expectedText: String) {
+  val content = asContentText()
+  Assert.assertEquals(expectedText, content)
+}
+
+/***
+ * Recursively tries to build a string out of the node contents
+ */
+fun Node<*>.asContentText(): String? = if (this is TextNode) {
+  this.content
+} else {
+  getChildren()?.joinToString("") { it.asContentText().orEmpty() }
+}
+
+inline fun <reified T : Node<*>> List<Node<*>>.assertNodeContents(vararg nodeContent: String) {
+  val listItemNodes = ArrayList<T>()
+  ASTUtils.traversePreOrder(this) {
+    if (it is T) {
+      listItemNodes.add(it)
+    }
+  }
+  Assert.assertTrue("No instances of ${T::class} found in $this", listItemNodes.isNotEmpty())
+
+  nodeContent.forEachIndexed { index, expected ->
+    listItemNodes[index].assertItemText(expected)
+  }
+
+  Assert.assertEquals(
+      "Differing node counts:\n  Expected: ${nodeContent.joinToString()}\n\n  Actual: $this",
+      nodeContent.size, listItemNodes.size)
+}

--- a/simpleast-core/src/test/java/com/discord/simpleast/code/CodeRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/CodeRulesTest.kt
@@ -42,7 +42,7 @@ class CodeRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "// Inlined",
         "// Line comment",
         "/// Doc")
@@ -57,7 +57,7 @@ class CodeRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "# Inlined",
         "# Line comment")
   }
@@ -73,7 +73,7 @@ class CodeRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         """"maybe"""",
         """"lyte"""",
         """"hello
@@ -91,7 +91,7 @@ class CodeRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         """"maybe"""",
         """"lyte"""",
         """"hello
@@ -111,7 +111,7 @@ class CodeRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "0", "12", "123", "456"
     )
   }
@@ -126,7 +126,7 @@ class CodeRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "@Route",
         "def", " get",
         "pass"
@@ -144,7 +144,7 @@ class CodeRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "#[derive(HelperAttr)]\n",
         "struct", " Struct",
 //        "#[helper]"  // Not supported
@@ -176,7 +176,7 @@ class CodeRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "mod", " test",
         "use", "Arc",
         "pub", "struct", " Event",
@@ -206,7 +206,7 @@ class CodeRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "from", "import", "as",
         "def", " hello_world", "self",
         "try",

--- a/simpleast-core/src/test/java/com/discord/simpleast/code/CodeRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/CodeRulesTest.kt
@@ -1,0 +1,222 @@
+package com.discord.simpleast.code
+
+import com.discord.simpleast.assertNodeContents
+import com.discord.simpleast.core.node.Node
+import com.discord.simpleast.core.node.StyleNode
+import com.discord.simpleast.core.parser.Parser
+import com.discord.simpleast.core.simple.SimpleMarkdownRules
+import com.discord.simpleast.core.utils.TreeMatcher
+import org.junit.Before
+import org.junit.Test
+
+
+class CodeRulesTest {
+
+  private class TestState {}
+
+  private lateinit var parser: Parser<TestRenderContext, Node<TestRenderContext>, TestState>
+  private lateinit var treeMatcher: TreeMatcher
+
+  @Before
+  fun setup() {
+    parser = Parser()
+    val codeStyleProviders = CodeStyleProviders<TestRenderContext>()
+    parser.addRule(CodeRules.createCodeRule(
+        codeStyleProviders.defaultStyleProvider,
+        CodeRules.createCodeLanguageMap(codeStyleProviders))
+    )
+    parser.addRules(SimpleMarkdownRules.createSimpleMarkdownRules())
+    treeMatcher = TreeMatcher()
+    treeMatcher.registerDefaultMatchers()
+  }
+
+  @Test
+  fun commentsRust() {
+    val ast = parser.parse("""
+      ```rs
+      some.call() // Inlined
+      // Line comment
+      
+      /// Doc
+      fun X()
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "// Inlined",
+        "// Line comment",
+        "/// Doc")
+  }
+
+  @Test
+  fun commentsPython() {
+    val ast = parser.parse("""
+      ```py
+      some.call() # Inlined
+      # Line comment
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "# Inlined",
+        "# Line comment")
+  }
+
+  @Test
+  fun stringsRust() {
+    val ast = parser.parse("""
+      ```rs
+      call.me("maybe")
+      name = "lyte";
+      multi= "hello
+          world";
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        """"maybe"""",
+        """"lyte"""",
+        """"hello
+        |    world"""".trimMargin(),)
+  }
+
+  @Test
+  fun stringsPython() {
+    val ast = parser.parse("""
+      ```py
+      call.me("maybe")
+      name = "lyte";
+      multi= "hello
+          world";
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        """"maybe"""",
+        """"lyte"""",
+        """"hello
+        |    world"""".trimMargin(),)
+  }
+
+  /**
+   * Since number literals is generic we don't need specific language tests
+   */
+  @Test
+  fun numbers() {
+    val ast = parser.parse("""
+      ```py
+      x = 0
+      x += 12
+      add(123, 456)
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "0", "12", "123", "456"
+    )
+  }
+
+  @Test
+  fun annotationsPython() {
+    val ast = parser.parse("""
+      ```py
+      @Route(method=GET)
+      def get(user):
+        pass
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "@Route",
+        "def", " get",
+        "pass"
+    )
+  }
+
+  @Test
+  fun annotationsRust() {
+    val ast = parser.parse("""
+      ```rs
+      #[derive(HelperAttr)]
+      struct Struct {
+          #[helper] field: ()
+      }
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "#[derive(HelperAttr)]\n",
+        "struct", " Struct",
+//        "#[helper]"  // Not supported
+    )
+  }
+
+  @Test
+  fun keywordsRust() {
+    val ast = parser.parse("""
+      ```rs
+      mod test {
+        use std::sync::Arc
+        
+        pub struct Event {name: A, value: B}
+        
+        impl<T: Clone, V> Event<T, V>
+        where
+          V: Clone + Send + Sync
+        {
+          async fn count(&self, req: T) -> Result<usize, String>{
+            let limit = match req.limit {
+              0 => usize::max_value(),
+              _ => req.limit,
+            }
+            return Ok(self.count(limit).await?);
+          }
+        }
+      }
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "mod", " test",
+        "use", "Arc",
+        "pub", "struct", " Event",
+        "impl", "Clone",
+        "where", "Clone", "Send", "Sync",
+        "async", "fn", "self", "Result", "usize", "String",
+        "let", "match", "0", "usize",
+        "return", "Ok", "self", "await",
+    )
+  }
+
+  @Test
+  fun keywordsPython() {
+    val ast = parser.parse("""
+      ```py
+      from com.discord import test as _test
+      def hello_world(self, name, interests):
+        try
+          for entry in interests:
+            if entry is None and not False:
+              raise 0
+            continue
+        except:
+          pass
+        finally:
+          return
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "from", "import", "as",
+        "def", " hello_world", "self",
+        "try",
+        "for", "in",
+        "if", "is", "None", "and", "not", "False",
+        "raise", "0",
+        "continue",
+        "except",
+        "pass",
+        "finally",
+        "return")
+  }
+}

--- a/simpleast-core/src/test/java/com/discord/simpleast/code/KotlinRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/KotlinRulesTest.kt
@@ -44,7 +44,7 @@ class KotlinRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         """
           /** Multiline
               Comment
@@ -63,7 +63,7 @@ class KotlinRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         """"hello"""",
         """"world"""")
   }
@@ -81,7 +81,7 @@ class KotlinRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "\"\"",
         """
           ${'"'}
@@ -102,7 +102,7 @@ class KotlinRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "@Test",
         "@Nullable",
     )
@@ -137,7 +137,7 @@ class KotlinRulesTest {
       ```
     """.trimIndent(), TestState())
 
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         """
         /*
           private override fun <T> test(x:T) {
@@ -174,7 +174,7 @@ class KotlinRulesTest {
       }
       ```
     """.trimIndent(), TestState())
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
         "package", "import",
         "while", "true", "123", "break",
         "if", "false",
@@ -191,7 +191,7 @@ class KotlinRulesTest {
       add(123,456)
       ```
     """.trimIndent(), TestState())
-    ast.assertNodeContents<StyleNode.Text<*>>(
+    ast.assertNodeContents<StyleNode.TextStyledNode<*>>(
             "0", "12", "123", "456"
    )
   }

--- a/simpleast-core/src/test/java/com/discord/simpleast/code/KotlinRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/KotlinRulesTest.kt
@@ -1,0 +1,250 @@
+package com.discord.simpleast.code
+
+import com.discord.simpleast.assertNodeContents
+import com.discord.simpleast.core.node.Node
+import com.discord.simpleast.core.node.StyleNode
+import com.discord.simpleast.core.parser.Parser
+import com.discord.simpleast.core.simple.SimpleMarkdownRules
+import com.discord.simpleast.core.utils.TreeMatcher
+import org.junit.Before
+import org.junit.Test
+
+
+class KotlinRulesTest {
+
+  private class TestState
+
+  private lateinit var parser: Parser<TestRenderContext, Node<TestRenderContext>, TestState>
+  private lateinit var treeMatcher: TreeMatcher
+
+  @Before
+  fun setup() {
+    val codeStyleProviders = CodeStyleProviders<TestRenderContext>()
+    parser = Parser()
+    parser
+        .addRule(CodeRules.createCodeRule(
+            codeStyleProviders.defaultStyleProvider,
+            CodeRules.createCodeLanguageMap(codeStyleProviders))
+        )
+        .addRules(SimpleMarkdownRules.createSimpleMarkdownRules())
+    treeMatcher = TreeMatcher()
+    treeMatcher.registerDefaultMatchers()
+  }
+
+  @Test
+  fun comments() {
+    val ast = parser.parse("""
+      ```kt
+      /** Multiline
+          Comment
+      */
+      some.call() // Inlined
+      // Line comment
+      
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        """
+          /** Multiline
+              Comment
+          */
+        """.trimIndent(),
+        "// Inlined",
+        "// Line comment")
+  }
+
+  @Test
+  fun strings() {
+    val ast = parser.parse("""
+      ```kt
+      call("hello")
+      x = "world"
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        """"hello"""",
+        """"world"""")
+  }
+
+  @Test
+  fun stringsMultiline() {
+    val multiLineQuote = "\"".repeat(3)
+
+    val ast = parser.parse("""
+      ```kt
+      text = $multiLineQuote
+      hello
+      world
+      $multiLineQuote
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "\"\"",
+        """
+          ${'"'}
+          hello
+          world
+          ${'"'}
+        """.trimIndent(),
+        "\"\""
+    )
+  }
+
+  @Test
+  fun annotations() {
+    val ast = parser.parse("""
+      ```kt
+      @Test(exception=Exception)
+      call(@Nullable t: Test)
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "@Test",
+        "@Nullable",
+    )
+  }
+
+  @Test
+  fun functions() {
+    val ast = parser.parse("""
+      ```kt
+      private override fun <T> test(x: T) {
+        // Implementation
+      }
+
+      fun getVal() = value
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<Kotlin.FunctionNode<*>>("fun <T> test(x: T)", "fun getVal()")
+  }
+
+  @Test
+  fun commentedFunction() {
+    val ast = parser.parse("""
+      ```kt
+      /*
+        private override fun <T> test(x:T) {
+          throw Exception()
+        }
+      */
+      // public fun foo() {}
+      call(x /* test var */)
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        """
+        /*
+          private override fun <T> test(x:T) {
+            throw Exception()
+          }
+        */
+        """.trimIndent(),
+        "// public fun foo() {}",
+        "/* test var */")
+  }
+
+  @Test
+  fun keywords() {
+    val ast = parser.parse("""
+      ```kt
+      package com.test;
+      import com.test.unit;
+
+      while(true) {
+        add(i, 123)
+        break;
+      }
+      if (false) {}
+
+      open _class X {}
+      abstract _fun x()
+
+      try {
+      } catch(e: Exception) {
+        when(e.type) {
+        }
+      } finally {
+        return
+      }
+      ```
+    """.trimIndent(), TestState())
+    ast.assertNodeContents<StyleNode.Text<*>>(
+        "package", "import",
+        "while", "true", "123", "break",
+        "if", "false",
+        "open", "abstract",
+        "try", "catch", "when", "finally", "return")
+  }
+
+  @Test
+  fun numbers() {
+    val ast = parser.parse("""
+      ```kt
+      x = 0
+      x += 12
+      add(123,456)
+      ```
+    """.trimIndent(), TestState())
+    ast.assertNodeContents<StyleNode.Text<*>>(
+            "0", "12", "123", "456"
+   )
+  }
+
+  @Test
+  fun fields() {
+    val ast = parser.parse("""
+      ```kt
+      private val x: Int = 4
+      public val y = 123
+      private const val CODE = 2
+      val z =
+        Foo("bar")
+        ```
+    """.trimIndent(), TestState())
+    ast.assertNodeContents<Kotlin.FieldNode<*>>(
+        "val x",
+        "val y",
+        "val CODE",
+        "val z")
+  }
+
+  @Test
+  fun classDef() {
+    val ast = parser.parse("""
+      ```kt
+      class Foo(bar: String, callaback: () -> Unit) {
+        fun test() {}
+
+        data class Bar {}
+      }
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<CodeNode.DefinitionNode<*>>(
+        "class Foo",
+        "class Bar")
+    ast.assertNodeContents<Kotlin.FunctionNode<*>>("fun test()")
+  }
+
+
+  @Test
+  fun interfaceDef() {
+    val ast = parser.parse("""
+      ```kt
+      interface CodeLanguageState<Self : CodeLanguageState<Self>> {
+        val langauge: String?  // Inline
+        var isCommentBlock: Boolean
+      }
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<CodeNode.DefinitionNode<*>>("interface CodeLanguageState")
+    ast.assertNodeContents<Kotlin.FieldNode<*>>("val langauge", "var isCommentBlock")
+  }
+}

--- a/simpleast-core/src/test/java/com/discord/simpleast/code/TestRenderContext.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/TestRenderContext.kt
@@ -1,0 +1,5 @@
+package com.discord.simpleast.code
+
+import android.graphics.Color
+
+internal class TestRenderContext


### PR DESCRIPTION
Adds support to highlight code for `Kotlin, Python, Rust, XML, ProtoBuff`. Kotlin has some additional support, but it wouldn't be hard to add  it for other languages too.

# Feature
New `CodeRule + CodeNode` added to the library.
- `CodeNode` does a bit of span-fu, see inlined documentation. Basically it makes sure that styles applied by the `CodeNode` apply first, then the child styles are applied. This prevents the `CodeNode` styles from overwriting the styles of the children.
- Nodes are passed in a `CodeStyleProviders` which provides it a way of creating styled spannables for the different values. This is how we can configure the styling in the client to use whatever styles we want.

Eventually this should support Textmate [language extensions](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#tokenization)

## Adding new language:
Adding simple support for new languages can be done by defining 3 things:
- line comment prefix
- built in types
- keywords

Example of adding a language:
```kotlin
val pythonRules = createGenericCodeRules<R, S>(
    codeStyleProviders,
    additionalRules = listOf(
        createSingleLineCommentPattern("#")
            .toFullMatchRule(codeStyleProviders.commentStyleProvider),
        Pattern.compile("""^@(\w+)""")
            .toFullMatchRule(codeStyleProviders.genericsStyleProvider)),
    definitions = arrayOf("class", "def", "lambda"),
    builtIns = arrayOf("True|False|None"),
    /* keywords */"from|import|global|nonlocal",
    "async|await|class|self|cls|def|lambda",
)
```

## Additional changes
-New StyleNode.Text for a bit more optimized `Node` structure used for CodeNode
- added a basic `BlockBackgroundNode` similar to what we have in discord to the sample app

## Screens
![image](https://user-images.githubusercontent.com/5618601/97063531-1abe1380-1555-11eb-9674-1d3748d16b2a.png)