### PR TITLE
Fix: Code block with single word case

### DIFF
--- a/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
@@ -189,8 +189,9 @@ object SampleTexts {
 
   const val CODE_BLOCKS = """
     # Code block samples
-    inlined:```kt private fun test() {}```
-    inlined:```kt private fun test() {
+    inlined:```py language code blocks need newline```
+    inlined:```kt 
+    private fun test() {
       some.call()
     }```
     

--- a/simpleast-core/build.gradle
+++ b/simpleast-core/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 30
         versionCode 28
-        versionName "2.1.1"
+        versionName "2.1.2"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -23,8 +23,9 @@ object CodeRules {
    * Handles markdown syntax for code blocks for a given language.
    *
    * Examples:
-   * inlined ```kt fun test()```
-   * inlined2 ```kt
+   * inlined ```test```
+   * inlined ```kt language code blocks need newline```
+   * inlined block start ```kt
    * fun test()
    * ```
    *
@@ -37,7 +38,7 @@ object CodeRules {
    * ```
    */
   val PATTERN_CODE_BLOCK: Pattern =
-      Pattern.compile("""^```(?:([A-z0-9_+\-.]+))?(\s*)([^\n].*?)\n*```""", Pattern.DOTALL)
+      Pattern.compile("""^```(?:([\w+\-.]+?)(\s*\n))?([^\n].*?)\n*```""", Pattern.DOTALL)
 
   val PATTERN_CODE_INLINE: Pattern =
       Pattern.compile("""^`(?:\s*)([^\n].*?)\n*`""", Pattern.DOTALL)
@@ -226,7 +227,7 @@ object CodeRules {
           : ParseSpec<R, S> {
         val language = matcher.group(CODE_BLOCK_LANGUAGE_GROUP)
         val codeBody = matcher.group(CODE_BLOCK_BODY_GROUP).orEmpty()
-        val startsWithNewline = matcher.group(CODE_BLOCK_WS_PREFIX)!!.contains('\n')
+        val startsWithNewline = matcher.group(CODE_BLOCK_WS_PREFIX)?.contains('\n') ?: false
 
         val languageRules = language?.let { languageMap[it] }
 

--- a/simpleast-core/src/test/java/com/discord/simpleast/code/CodeRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/CodeRulesTest.kt
@@ -31,6 +31,19 @@ class CodeRulesTest {
   }
 
   @Test
+  fun noLanguageOneLined() {
+    val ast = parser.parse("""
+      ```code```
+      
+      ```spaces  ```
+      
+      ```some text```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<CodeNode<*>>("code", "spaces  ", "some text")
+  }
+
+  @Test
   fun commentsRust() {
     val ast = parser.parse("""
       ```rs


### PR DESCRIPTION
This has a side effect of making inlined code blocks require a newline to register the language.
However this caveat is also the same as the code rules we use on discord desktop.