### PR TITLE
Fix: Code Blocks with no immediate text

### DIFF
--- a/simpleast-core/build.gradle
+++ b/simpleast-core/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 30
         versionCode 28
-        versionName "2.1.2"
+        versionName "2.1.3"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -25,7 +25,7 @@ object CodeRules {
    * Examples:
    * inlined ```test```
    * inlined ```kt language code blocks need newline```
-   * inlined block start ```kt
+   * inlined block start ```
    * fun test()
    * ```
    *
@@ -38,7 +38,7 @@ object CodeRules {
    * ```
    */
   val PATTERN_CODE_BLOCK: Pattern =
-      Pattern.compile("""^```(?:([\w+\-.]+?)(\s*\n))?([^\n].*?)\n*```""", Pattern.DOTALL)
+      Pattern.compile("""^```(?:([\w+\-.]+?)?(\s*\n))?([^\n].*?)\n*```""", Pattern.DOTALL)
 
   val PATTERN_CODE_INLINE: Pattern =
       Pattern.compile("""^`(?:\s*)([^\n].*?)\n*`""", Pattern.DOTALL)

--- a/simpleast-core/src/test/java/com/discord/simpleast/code/CodeRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/CodeRulesTest.kt
@@ -44,6 +44,17 @@ class CodeRulesTest {
   }
 
   @Test
+  fun noLanguageBlocked() {
+    val ast = parser.parse("""
+      Sample: ```
+      **block text**
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<CodeNode<*>>("**block text**")
+  }
+
+  @Test
   fun commentsRust() {
     val ast = parser.parse("""
       ```rs


### PR DESCRIPTION
See test `CodeRulesTest.noLanguageBlocked`