### PR TITLE
[CI] Update to latest ubuntu LTS 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 
-dist: trusty
+dist: focal
 
 android:
   components:


### PR DESCRIPTION
Trusty is 14.04, which is 6 years old.

This was a bad copy and paste from me.