### PR TITLE
Fix: inline code rule shouldn't consume empty blocks

### DIFF
--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -35,7 +35,11 @@ class MainActivity : AppCompatActivity() {
     setContentView(R.layout.activity_main)
 
     parser = Parser<RenderContext, Node<RenderContext>, ParseState>()
-        .addRules(UserMentionRule(), CustomMarkdownRules.createBlockQuoteRule())
+        .addRules(
+            // Allow callers to escape markdown commands such as code block ticks
+            SimpleMarkdownRules.createEscapeRule(),
+            UserMentionRule(),
+            CustomMarkdownRules.createBlockQuoteRule())
         .addRules(CustomMarkdownRules.createMarkdownRules(
             this@MainActivity,
             listOf(R.style.Demo_Header_1, R.style.Demo_Header_2, R.style.Demo_Header_3),
@@ -43,7 +47,7 @@ class MainActivity : AppCompatActivity() {
         .addRules(
             CustomMarkdownRules.createCodeRule(this@MainActivity),
             CustomMarkdownRules.createCodeInlineRule(this@MainActivity))
-        .addRules(SimpleMarkdownRules.createSimpleMarkdownRules())
+        .addRules(SimpleMarkdownRules.createSimpleMarkdownRules(includeEscapeRule = false))
 
     resultText = findViewById(R.id.result_text)
     input = findViewById(R.id.input)

--- a/simpleast-core/build.gradle
+++ b/simpleast-core/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 30
         versionCode 28
-        versionName "2.1.3"
+        versionName "2.2.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -41,7 +41,7 @@ object CodeRules {
       Pattern.compile("""^```(?:([\w+\-.]+?)?(\s*\n))?([^\n].*?)\n*```""", Pattern.DOTALL)
 
   val PATTERN_CODE_INLINE: Pattern =
-      Pattern.compile("""^`(?:\s*)([^\n].*?)\n*`""", Pattern.DOTALL)
+      Pattern.compile("""^`([^`]*?)`""", Pattern.DOTALL)
 
   private const val CODE_BLOCK_LANGUAGE_GROUP = 1
   private const val CODE_BLOCK_WS_PREFIX = 2
@@ -252,6 +252,9 @@ object CodeRules {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S)
           : ParseSpec<R, S> {
         val codeBody = matcher.group(1).orEmpty()
+        if (codeBody.isEmpty()) {
+          return ParseSpec.createTerminal(TextNode(matcher.group()), state)
+        }
 
         val content = CodeNode.Content.Raw(codeBody)
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
@@ -69,7 +69,7 @@ object SimpleMarkdownRules {
   fun <R, S> createEscapeRule(): Rule<R, Node<R>, S> {
     return object : Rule<R, Node<R>, S>(PATTERN_ESCAPE) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S): ParseSpec<R,  S> {
-        return ParseSpec.createTerminal(TextNode(matcher.group(1)), state)
+        return ParseSpec.createTerminal(TextNode(matcher.group(1)!!), state)
       }
     }
   }
@@ -80,7 +80,7 @@ object SimpleMarkdownRules {
         val startIndex: Int
         val endIndex: Int
         val asteriskMatch = matcher.group(2)
-        if (asteriskMatch != null && asteriskMatch.length > 0) {
+        if (asteriskMatch != null && asteriskMatch.isNotEmpty()) {
           startIndex = matcher.start(2)
           endIndex = matcher.end(2)
         } else {
@@ -98,9 +98,11 @@ object SimpleMarkdownRules {
   }
 
   @JvmOverloads @JvmStatic
-  fun <R, S> createSimpleMarkdownRules(includeTextRule: Boolean = true): MutableList<Rule<R, Node<R>, S>> {
+  fun <R, S> createSimpleMarkdownRules(includeTextRule: Boolean = true, includeEscapeRule:Boolean = true): MutableList<Rule<R, Node<R>, S>> {
     val rules = ArrayList<Rule<R, Node<R>, S>>()
-    rules.add(createEscapeRule())
+    if (includeEscapeRule) {
+      rules.add(createEscapeRule())
+    }
     rules.add(createNewlineRule())
     rules.add(createBoldRule())
     rules.add(createUnderlineRule())


### PR DESCRIPTION
Empty inline blocks should behave as if they were just text.

Additionally add updates to sample app + test to handle escaping ticks

Bump the version to 2.2.0 for the change to `createSimpleMarkdownRules` API

Context:
This enables text such as
```
\```sample text``` 
```

to be rendered as:
```
```sample text```
```