### PR TITLE
code: support double ` inline codeblocks

### DIFF
--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -41,7 +41,7 @@ object CodeRules {
       Pattern.compile("""^```(?:([\w+\-.]+?)?(\s*\n))?([^\n].*?)\n*```""", Pattern.DOTALL)
 
   val PATTERN_CODE_INLINE: Pattern =
-      Pattern.compile("""^`([^`]*?)`""", Pattern.DOTALL)
+      Pattern.compile("""^`([^`]+)`|``([^`]+)``""", Pattern.DOTALL)
 
   private const val CODE_BLOCK_LANGUAGE_GROUP = 1
   private const val CODE_BLOCK_WS_PREFIX = 2


### PR DESCRIPTION
Added support for inline codeblocks that can be created with double \` (e.g. \`\`text\`\` -> ``text``) which is supported by Discord desktop, Discord mobile should consume the same rules and the inline codeblock rule should not consume empty inline codeblocks.