### PR TITLE
code: fix variable name highlighting

### DIFF
--- a/simpleast-core/src/main/java/com/discord/simpleast/code/JavaScript.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/JavaScript.kt
@@ -96,7 +96,7 @@ object JavaScript {
        * ```
        */
       private val PATTERN_JAVASCRIPT_FIELD =
-          Pattern.compile("""^(var|let|const)(\s+[a-zA-Z_$](?:[a-zA-Z0-9_$])*?)""", Pattern.DOTALL)
+          Pattern.compile("""^(var|let|const)(\s+[a-zA-Z_$](?:[a-zA-Z0-9_$])*)""", Pattern.DOTALL)
 
       fun <RC, S> createFieldRule(
           codeStyleProviders: CodeStyleProviders<RC>


### PR DESCRIPTION
The `?` here causes the `JavaScript` syntax highlighter to only highlight the first character in the variables instead of the rest of it, this PR fixes this.