### PR TITLE
code: fix JavaScript rules

### DIFF
--- a/simpleast-core/src/test/java/com/discord/simpleast/code/JavaScriptRuleTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/JavaScriptRuleTest.kt
@@ -107,13 +107,13 @@ class JavaScriptRulesTest {
     """.trimIndent(), TestState())
 
     ast.assertNodeContents<JavaScript.FunctionNode<*>>(
-      "function test(T)",
-      "function ()",
-      "function* generator()",
-      "static test()",
-      "async fetch()",
-      "get tokens()",
-      "set constants()")
+      "function test(T) {",
+      "function () {",
+      "function* generator() {",
+      "static test() {",
+      "async fetch() {",
+      "get tokens() {",
+      "set constants() {")
   }
 
   @Test


### PR DESCRIPTION
• Added the missing `from` keyword to the list of keywords.
• Made the function declaration pattern even stricter with the usage of a scope check so it doesn't match something like `.get(...)`.
• Fixed the object property declaration rule so it matches a property name that has spaces after it (e.g. `{ test : 1 }`).
• The regex and strings made of single and double quotation marks shouldn't match line breakers.