### PR TITLE
code: fix JavaScript rules

### DIFF
--- a/simpleast-core/src/test/java/com/discord/simpleast/code/JavaScriptRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/JavaScriptRulesTest.kt
@@ -107,13 +107,33 @@ class JavaScriptRulesTest {
     """.trimIndent(), TestState())
 
     ast.assertNodeContents<JavaScript.FunctionNode<*>>(
-      "function test(T) {",
-      "function () {",
-      "function* generator() {",
-      "static test() {",
-      "async fetch() {",
-      "get tokens() {",
-      "set constants() {")
+      "test(T) {",
+      "() {",
+      "generator() {",
+      "test() {",
+      "fetch() {",
+      "tokens() {",
+      "constants() {")
+  }
+
+  @Test
+  fun arrowFunctions() {
+    val ast = parser.parse("""
+      ```js
+        test => {}
+        test => h
+        (test) => {}
+        (test) => h
+        (...args) => {}
+      ```
+    """.trimIndent(), TestState())
+
+    ast.assertNodeContents<JavaScript.ArrowFunctionNode<*>>(
+      "test =>",
+      "test =>",
+      "(test) =>",
+      "(test) =>",
+      "(...args) =>")
   }
 
   @Test


### PR DESCRIPTION
• Made a few improvements to the pattern rules.
• Removed unused DOTALL additions.
• Made it so you can escape specific characters in the regex and generic rule patterns so they don't screw up the highlighting, such as escaping a backslash (`\`) in the regex declaration.
• Empty regexes is not highlighted any longer since they're invalid.
• Now the regex rule pattern only accepts the `d`, `g`, `i`, `m`, `s`, `u` and `y` flags.
• The function pattern rule now should match function declarations without a keyword prefix.
• Implemented a new pattern rule node that matches arrow functions.
• Renamed the JavaScript test file from `JavaScriptRuleTest` to `JavaScriptRulesTest` for consistency, fixed function rule node tests and added tests for the arrow function rule node.