### PR TITLE
fix(code): fix rules

### DIFF
--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -41,7 +41,7 @@ object CodeRules {
       Pattern.compile("""^```(?:([\w+\-.]+?)?(\s*\n))?([^\n].*?)\n*```""", Pattern.DOTALL)
 
   val PATTERN_CODE_INLINE: Pattern =
-      Pattern.compile("""^`([^`]*)`|``([^`]*)``""", Pattern.DOTALL)
+      Pattern.compile("""^(``?)([^`]*)\1""", Pattern.DOTALL)
 
   private const val CODE_BLOCK_LANGUAGE_GROUP = 1
   private const val CODE_BLOCK_WS_PREFIX = 2
@@ -291,7 +291,7 @@ object CodeRules {
     return object : Rule<R, Node<R>, S>(PATTERN_CODE_INLINE) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S)
           : ParseSpec<R, S> {
-        val codeBody = (matcher.group(1) ?: matcher.group(2)).orEmpty()
+        val codeBody = matcher.group(2).orEmpty()
         if (codeBody.isEmpty()) {
           return ParseSpec.createTerminal(TextNode(matcher.group()), state)
         }

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -41,7 +41,7 @@ object CodeRules {
       Pattern.compile("""^```(?:([\w+\-.]+?)?(\s*\n))?([^\n].*?)\n*```""", Pattern.DOTALL)
 
   val PATTERN_CODE_INLINE: Pattern =
-      Pattern.compile("""^`([^`]+)`|``([^`]+)``""", Pattern.DOTALL)
+      Pattern.compile("""^`([^`]*)`|``([^`]*)``""", Pattern.DOTALL)
 
   private const val CODE_BLOCK_LANGUAGE_GROUP = 1
   private const val CODE_BLOCK_WS_PREFIX = 2
@@ -291,7 +291,7 @@ object CodeRules {
     return object : Rule<R, Node<R>, S>(PATTERN_CODE_INLINE) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S)
           : ParseSpec<R, S> {
-        val codeBody = matcher.group(1).orEmpty()
+        val codeBody = (matcher.group(1) ?: matcher.group(2)).orEmpty()
         if (codeBody.isEmpty()) {
           return ParseSpec.createTerminal(TextNode(matcher.group()), state)
         }

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/JavaScript.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/JavaScript.kt
@@ -42,12 +42,12 @@ object JavaScript {
   )
 
   class FunctionNode<RC>(
-    signature: String?, params: String, scope: String,
+    pre: String, signature: String?, params: String,
     codeStyleProviders: CodeStyleProviders<RC>
   ) : Node.Parent<RC>(
+      StyleNode.TextStyledNode(pre, codeStyleProviders.keywordStyleProvider),
       signature?.let { StyleNode.TextStyledNode(signature, codeStyleProviders.identifierStyleProvider) },
-      StyleNode.TextStyledNode(params, codeStyleProviders.paramsStyleProvider),
-      StyleNode.TextStyledNode(scope, codeStyleProviders.defaultStyleProvider)
+      StyleNode.TextStyledNode(params, codeStyleProviders.paramsStyleProvider)
   ) {
       companion object {
         /**
@@ -64,47 +64,15 @@ object JavaScript {
          * ```
          */
          private val PATTERN_JAVASCRIPT_FUNC = 
-             """^([a-zA-Z_$][a-zA-Z0-9_$]*)?(\s*\(.*\))(\s*\{)""".toRegex(RegexOption.DOT_MATCHES_ALL).toPattern()
+             """^(function\*?|static|get|set|async)(\s+[a-zA-Z_$][a-zA-Z0-9_$]*)?(\s*\(.*?\))""".toRegex(RegexOption.DOT_MATCHES_ALL).toPattern()
 
          fun <RC, S> createFunctionRule(codeStyleProviders: CodeStyleProviders<RC>) =
           object : Rule<RC, Node<RC>, S>(PATTERN_JAVASCRIPT_FUNC) {
             override fun parse(matcher: Matcher, parser: Parser<RC, in Node<RC>, S>, state: S): ParseSpec<RC, S> {
-              val signature = matcher.group(1)
-              val params = matcher.group(2)
-              val scope = matcher.group(3)
-              return ParseSpec.createTerminal(FunctionNode(signature, params!!, scope!!, codeStyleProviders), state)
-            }
-          }
-    }
-  }
-
-  class ArrowFunctionNode<RC>(
-      params: String, arrow: String,
-      codeStyleProviders: CodeStyleProviders<RC>
-  ) : Node.Parent<RC>(
-      StyleNode.TextStyledNode(params, codeStyleProviders.paramsStyleProvider),
-      StyleNode.TextStyledNode(arrow, codeStyleProviders.defaultStyleProvider)
-  ) {
-      companion object {
-        /**
-         * Matches againt a JavaScript arrow function declaration.
-         *
-         * ```
-         * file => {}
-         * file => !file
-         * (file) => 1
-         * () => {}
-         * ```
-         */
-         private val PATTERN_JAVASCRIPT_ARROW_FUNC =
-             """^([a-zA-Z_$][a-zA-Z0-9_$]*|\(.*\))(\s*=>)""".toRegex(RegexOption.DOT_MATCHES_ALL).toPattern()
-
-         fun <RC, S> createArrowFunctionRule(codeStyleProviders: CodeStyleProviders<RC>) =
-          object : Rule<RC, Node<RC>, S>(PATTERN_JAVASCRIPT_ARROW_FUNC) {
-            override fun parse(matcher: Matcher, parser: Parser<RC, in Node<RC>, S>, state: S): ParseSpec<RC, S> {
-              val params = matcher.group(1)
-              val arrow = matcher.group(2)
-              return ParseSpec.createTerminal(ArrowFunctionNode(params!!, arrow!!, codeStyleProviders), state)
+              val pre = matcher.group(1)
+              val signature = matcher.group(2)
+              val params = matcher.group(3)
+              return ParseSpec.createTerminal(FunctionNode(pre!!, signature, params!!, codeStyleProviders), state)
             }
           }
     }
@@ -234,6 +202,5 @@ object JavaScript {
           PATTERN_JAVASCRIPT_REGEX.toMatchGroupRule(stylesProvider = codeStyleProviders.literalStyleProvider),
           FieldNode.createFieldRule(codeStyleProviders),
           FunctionNode.createFunctionRule(codeStyleProviders),
-          ArrowFunctionNode.createArrowFunctionRule(codeStyleProviders),
       )
 }

--- a/simpleast-core/src/test/java/com/discord/simpleast/code/JavaScriptRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/code/JavaScriptRulesTest.kt
@@ -107,33 +107,13 @@ class JavaScriptRulesTest {
     """.trimIndent(), TestState())
 
     ast.assertNodeContents<JavaScript.FunctionNode<*>>(
-      "test(T) {",
-      "() {",
-      "generator() {",
-      "test() {",
-      "fetch() {",
-      "tokens() {",
-      "constants() {")
-  }
-
-  @Test
-  fun arrowFunctions() {
-    val ast = parser.parse("""
-      ```js
-        test => {}
-        test => h
-        (test) => {}
-        (test) => h
-        (...args) => {}
-      ```
-    """.trimIndent(), TestState())
-
-    ast.assertNodeContents<JavaScript.ArrowFunctionNode<*>>(
-      "test =>",
-      "test =>",
-      "(test) =>",
-      "(test) =>",
-      "(...args) =>")
+      "function test(T)",
+      "function () {",
+      "function* generator() {",
+      "static test() {",
+      "async fetch() {",
+      "get tokens() {",
+      "set constants() {")
   }
 
   @Test


### PR DESCRIPTION
Fixed the rules screwing up the syntax highlighting.

Here are the benchmarks for finalizing the double backtick inline codeblocks:

**The input of "\`test\` \`\`test\`\`" copy-pasted 500 times has been benchmarked in the following results.**

Old (Without double backtick inline codeblock support): average parse time of ~450-460 milliseconds.
New (With double backtick inline codeblock support): average parse time of ~460-600 milliseconds.

**The same tests as above has been benchmarked but also with the benchmark text found in the samples for the following results.**

Old (Without double backtick inline codeblock support): average parse time of ~760-830 milliseconds.
New (With double backtick inline codeblock support): average parse time of ~950-1090 milliseconds.

There are no performance regressions.