### PR TITLE
feat(code): add syntax highlighting for Diff

### DIFF
--- a/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/SampleTexts.kt
@@ -297,6 +297,18 @@ object SampleTexts {
     ```
   """
 
+  private const val CODE_BLOCK_DIFF = """
+    Diff code block:
+    ```diff
+    - "This car is amzing!"
+    + "This car is amazing!"
+    - 1
+    + 100
+    - This house is not cheap.
+    + This house is expensive.
+    ```
+  """
+
   const val CODE_BLOCKS = """
     # Code block samples
     inlined:```py language code blocks need newline```
@@ -314,6 +326,7 @@ object SampleTexts {
     $CODE_BLOCK_CRYSTAL
     $CODE_BLOCK_JAVASCRIPT
     $CODE_BLOCK_TYPESCRIPT
+    $CODE_BLOCK_DIFF
     
     That should do it....
   """

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -214,6 +214,15 @@ object CodeRules {
         keywords = TypeScript.KEYWORDS,
         types = TypeScript.TYPES
     )
+
+    val diffRules = listOf<Rule<R, Node<R>, S>>(
+        Pattern.compile("""^-.*""")
+            .toMatchGroupRule(stylesProvider = codeStyleProviders.keywordStyleProvider),
+        Pattern.compile("""^\+.*""")
+            .toMatchGroupRule(stylesProvider = codeStyleProviders.typesStyleProvider),
+        PATTERN_LEADING_WS_CONSUMER.toMatchGroupRule(),
+        PATTERN_TEXT.toMatchGroupRule()
+    )
     
     return mapOf(
         "kt" to kotlinRules,
@@ -242,7 +251,9 @@ object CodeRules {
         "javascript" to javascriptRules,
         
         "ts" to typescriptRules,
-        "typescript" to typescriptRules
+        "typescript" to typescriptRules,
+
+        "diff" to diffRules
     )
   }
 


### PR DESCRIPTION
Added syntax highlighting support for Diff (`diff`).

![Screenshot_20220212-183057_Quickstep](https://user-images.githubusercontent.com/62040526/155607107-41558244-66c6-4137-bdd2-bafd5c61994d.png)